### PR TITLE
Fix `@babel/runtime` not found in `material-ui`

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   "author": "abalone0204",
   "license": "MIT",
   "dependencies": {
+    "@babel/runtime": "^7.0.0-beta.47",
     "babel-eslint": "^8.2.2",
     "body-parser": "^1.18.2",
     "dotenv": "^4.0.0",


### PR DESCRIPTION
When I running  `$ npm run dev` command, it comes up with following error message on home page.

```
Error in ./withStyles
Module not found: Error: Can't resolve '@babel/runtime/core-js/map' in '/Users/than/Source/BiiLabs/TangleID/node_modules/material-ui/styles'
ModuleNotFoundError: Module not found: Error: Can't resolve '@babel/runtime/core-js/map' in '/Users/than/Source/BiiLabs/TangleID/node_modules/material-ui/styles'
    at factoryCallback (/Users/than/Source/BiiLabs/TangleID/node_modules/next/node_modules/webpack/lib/Compilation.js:269:40)
    at factory (/Users/than/Source/BiiLabs/TangleID/node_modules/next/node_modules/webpack/lib/NormalModuleFactory.js:235:20)
    at resolver (/Users/than/Source/BiiLabs/TangleID/node_modules/next/node_modules/webpack/lib/NormalModuleFactory.js:60:20)
    at asyncLib.parallel (/Users/than/Source/BiiLabs/TangleID/node_modules/next/node_modules/webpack/lib/NormalModuleFactory.js:127:20)
    at /Users/than/Source/BiiLabs/TangleID/node_modules/next/node_modules/async/dist/async.js:3874:9
    at /Users/than/Source/BiiLabs/TangleID/node_modules/next/node_modules/async/dist/async.js:473:16
    at iteratorCallback (/Users/than/Source/BiiLabs/TangleID/node_modules/next/node_modules/async/dist/async.js:1048:13)
    at /Users/than/Source/BiiLabs/TangleID/node_modules/next/node_modules/async/dist/async.js:958:16
    at /Users/than/Source/BiiLabs/TangleID/node_modules/next/node_modules/async/dist/async.js:3871:13
    at resolvers.normal.resolve (/Users/than/Source/BiiLabs/TangleID/node_modules/next/node_modules/webpack/lib/NormalModuleFactory.js:119:22)
```

This problem is caused by  `material-ui`  [[link]](https://github.com/mui-org/material-ui/issues/11285), so I fix it by installing `@babel/runtime` into package.json for now.

Since it has been fixed since v1.0.0-beta.47, do we have a plan upgrade to the latest stable version v1.0.0? 🤔 