### PR TITLE
Upgrade "material-ui" to v1.0.0

### DIFF
--- a/components/Loader/index.js
+++ b/components/Loader/index.js
@@ -1,6 +1,7 @@
 import PropTypes from 'prop-types'
-import { withStyles } from 'material-ui/styles'
-import { CircularProgress } from 'material-ui/Progress'
+
+import { withStyles } from '@material-ui/core/styles'
+import CircularProgress from '@material-ui/core/CircularProgress'
 
 const styles = theme => ({
 	progress: {
@@ -17,7 +18,7 @@ function CircularIndeterminate (props) {
 	return (
 		<div>
 			{isLoading &&
-          <CircularProgress className={classes.progress} size={100}/>
+				<CircularProgress className={classes.progress} size={100}/>
 			}
 		</div>
 	)

--- a/components/LoginDialog/index.js
+++ b/components/LoginDialog/index.js
@@ -1,11 +1,14 @@
-import React from 'react'
-import Button from 'material-ui/Button'
+import React, { Component } from 'react'
+import { withStyles } from '@material-ui/core'
+
+import Button from '@material-ui/core/Button'
+import Dialog from '@material-ui/core/Dialog'
+import DialogActions from '@material-ui/core/DialogActions'
+import DialogContent from '@material-ui/core/DialogContent'
+import DialogTitle from '@material-ui/core/DialogTitle'
+
 import SimpleForm from '../SimpleForm'
-import Dialog, {
-	DialogActions,
-	DialogContent,
-	DialogTitle,
-} from 'material-ui/Dialog'
+
 
 const styles = {
 	button: {
@@ -13,7 +16,7 @@ const styles = {
 	},
 }
 
-export default class LoginDialog extends React.Component {
+class LoginDialog extends Component {
 
 	state = {
 		open: false,
@@ -76,3 +79,5 @@ export default class LoginDialog extends React.Component {
 		)
 	}
 }
+
+export default withStyles(styles)(LoginDialog)

--- a/components/NewUserForm/index.js
+++ b/components/NewUserForm/index.js
@@ -1,10 +1,9 @@
 import PropTypes from 'prop-types'
-import { withStyles } from 'material-ui/styles'
-import Card, { CardActions, CardContent } from 'material-ui/Card'
-// import TextField from 'material-ui/TextField'
-// import Button from 'material-ui/Button'
-// import Icon from 'material-ui/Icon'
-import Typography from 'material-ui/Typography'
+import { withStyles } from '@material-ui/core/styles'
+
+import Card from '@material-ui/core/Card'
+import CardContent from '@material-ui/core/CardContent'
+import Typography from '@material-ui/core/Typography'
 import SimpleForm from '../SimpleForm'
 
 const styles = theme => ({

--- a/components/SimpleForm/index.js
+++ b/components/SimpleForm/index.js
@@ -1,8 +1,10 @@
 import PropTypes from 'prop-types'
-import { withStyles } from 'material-ui/styles'
-import TextField from 'material-ui/TextField'
-import Button from 'material-ui/Button'
-import Send from 'material-ui-icons/Send'
+import { withStyles } from '@material-ui/core/styles'
+
+import TextField from '@material-ui/core/TextField'
+import Button from '@material-ui/core/Button'
+
+import Send from '@material-ui/icons/Send'
 
 const styles = theme => ({
 	button: {

--- a/components/material/Nav.js
+++ b/components/material/Nav.js
@@ -1,5 +1,7 @@
 import Link from 'next/link'
-import { ListItem, ListItemIcon, ListItemText } from 'material-ui/List'
+
+import ListItem from '@material-ui/core/ListItem'
+import ListItemText from '@material-ui/core/ListItemText'
 
 const Nav = () => (
 	<nav>

--- a/components/material/PersistentDrawer.js
+++ b/components/material/PersistentDrawer.js
@@ -1,21 +1,22 @@
-import React from 'react';
-import PropTypes from 'prop-types';
-import { withStyles } from 'material-ui/styles';
-import classNames from 'classnames';
-import Drawer from 'material-ui/Drawer';
-import AppBar from 'material-ui/AppBar';
-import Toolbar from 'material-ui/Toolbar';
-import List from 'material-ui/List';
-import { MenuItem } from 'material-ui/Menu';
-import Typography from 'material-ui/Typography';
-import TextField from 'material-ui/TextField';
-import Divider from 'material-ui/Divider';
-import IconButton from 'material-ui/IconButton';
-import MenuIcon from 'material-ui-icons/Menu';
-import ChevronLeftIcon from 'material-ui-icons/ChevronLeft';
-import ChevronRightIcon from 'material-ui-icons/ChevronRight';
+import React from 'react'
+import PropTypes from 'prop-types'
+
+import classNames from 'classnames'
+import Drawer from '@material-ui/core/Drawer'
+import AppBar from '@material-ui/core/AppBar'
+import Toolbar from '@material-ui/core/Toolbar'
+import List from '@material-ui/core/List'
+import Typography from '@material-ui/core/Typography'
+import Divider from '@material-ui/core/Divider'
+import IconButton from '@material-ui/core/IconButton'
+import { withStyles } from '@material-ui/core/styles'
+
+import MenuIcon from '@material-ui/icons/Menu'
+import ChevronLeftIcon from '@material-ui/icons/ChevronLeft'
+import ChevronRightIcon from '@material-ui/icons/ChevronRight'
+
 import LoginDialog from '../LoginDialog'
-import Nav from './Nav';
+import Nav from './Nav'
 
 const drawerWidth = 240;
 

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
   "author": "TangleID",
   "license": "MIT",
   "dependencies": {
-    "@babel/runtime": "^7.0.0-beta.47",
+    "@material-ui/core": "^1.0.0",
+    "@material-ui/icons": "^1.0.0",
     "babel-eslint": "^8.2.2",
     "body-parser": "^1.18.2",
     "dotenv": "^4.0.0",
@@ -31,8 +32,6 @@
     "isomorphic-unfetch": "^2.0.0",
     "lodash": "^4.17.4",
     "lokijs": "^1.5.3",
-    "material-ui": "^1.0.0-beta.33",
-    "material-ui-icons": "^1.0.0-beta.17",
     "next": "^4.1.4",
     "next-redux-wrapper": "^1.3.4",
     "qrcode": "^1.0.0",

--- a/pages/users/new.js
+++ b/pages/users/new.js
@@ -8,7 +8,6 @@ import updateAccountStore from '../../actions/updateAccountStore'
 import Layout from '../../layouts/material/Main'
 import NewUserForm from '../../components/NewUserForm'
 import LoginDialog from '../../components/LoginDialog'
-import Grid from 'material-ui/Grid'
 
 const gen_uuid = () => {
 	const validChar = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ9'


### PR DESCRIPTION
Releated #5 
I upgrade the `material-ui` to latest version v1.0.0, so we don't need to install the `@babel/runtime` in our dpendencies.

Something you should remind: 
 - The latest version `material-ui` namespace is changed:
   -  Use `@material-ui/core` instead of `material-ui`.
   -  Use `@material-ui/icons` instead of `material-ui-icons` 

🚀 🚀 🚀 