### PR TITLE
Remove pm2 from development workflow 

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,11 +7,10 @@
     "node": "8.9.1"
   },
   "scripts": {
-    "preinstall": "npm install pm2 -g",
     "heroku-postbuild": "npm run build",
     "eslint": "eslint actions components constants layouts middlewares pages reducers store utils",
-    "dev": "pm2 start server.js --watch server.js --watch utils --watch next.config.js && pm2 logs server",
-    "start": "NODE_ENV=production pm2 start server.js -i max --attach",
+    "dev": "node server.js",
+    "start": "NODE_ENV=production node server.js",
     "build": "NODE_ENV=production next build",
     "test": "echo \"Error: no test specified\" && exit 1",
     "commit": "git-cz"
@@ -49,8 +48,7 @@
   "devDependencies": {
     "cz-conventional-changelog": "^2.1.0",
     "eslint": "^4.19.1",
-    "eslint-plugin-react": "^7.5.1",
-    "pm2": "^2.8.0"
+    "eslint-plugin-react": "^7.5.1"
   },
   "config": {
     "commitizen": {


### PR DESCRIPTION
The pm2 is a production managment tool.
We should focus on developing the TangleID so remove the pm2.
And it should be added in our production environment.