### PR TITLE
Fix failed to show user list page

### DIFF
--- a/reducers/users.js
+++ b/reducers/users.js
@@ -112,7 +112,7 @@ const offTangleData = (state = [], action) => {
   }
 };
 
-const localList = (state = {}, action) => {
+const localList = (state = [], action) => {
   switch (action.type) {
     case FETCH_LOCAL_ACCOUNT_SUCCESS:
       return action.response;


### PR DESCRIPTION
Related #32 
Because giving the wrong default value empty object to the "localList",
the "checkTangleUsers" function is trying to use "localList" as an array.
By giving the correct default value [] to "localList", the problem should
be fixed.