### PR TITLE
Remove Heroku script

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,6 @@
     "node": "8.9.1"
   },
   "scripts": {
-    "heroku-postbuild": "npm run build",
     "eslint": "eslint actions components constants layouts middlewares pages reducers store utils",
     "dev": "node server.js",
     "start": "NODE_ENV=production node server.js",


### PR DESCRIPTION
Heroku is a service to host the user application.

Since we no longer use the Heroku, so we remove the script for Heroku.