### PR TITLE
Correct link reference

### DIFF
--- a/components/ClaimList.js
+++ b/components/ClaimList.js
@@ -8,7 +8,7 @@ class ClaimList extends Component {
       <div>
         {this.props.claims.map(claim => (
           <div key={`claim-${claim}`}>
-            <Link href={`/claims/info/?hash_txn=${JSON.stringify(claim)}`} as={`/claims/info/${claim}`}>
+            <Link href={`/claims/info/${claim}`} as={`/claims/info/${claim}`}>
               <a>{claim}</a>
             </Link>
           </div>


### PR DESCRIPTION
Since the link reference to the wrong URL, the server cannot preload the
page on the server-side when the link is clicked, causing the server
crashed.

By setting the link correctly, fix the problem.