### PR TITLE
Canonicalize environment variable identifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,20 +55,18 @@ device is lost.
 
 TangleID uses [swarm node](https://github.com/yillkid/iota-swarm-node) as backend to interact with Tangle.
 
-- Create new file named `.env` and specify `BACKEND` and `API_HOST`
-  * `BACKEND`: an address (IP or domain) to the swarm node.
+- Create new file named `.env` and specify `IRI_HOST`, `SWARM_HOST` and `API_HOST`
+  * `IRI_HOST`: an address (IP or domain) to the IRI node.
+  * `SWARM_HOST`: an address (IP or domain) to the swarm node that implements the TangleID API.
   * `API_HOST`: main entry point for the API that TangleID invokes on client side.
 
 ```
-BACKEND=http://node2.puyuma.org:8000
+IRI_HOST=http://node2.puyuma.org:8000
+SWARM_HOST=http://node2.puyuma.org:8000
 API_HOST=http://localhost:3000/api
 ```
 
-You can setup your swarm node, and change the `.env`.
-```
-BACKEND=SWARM_NODE_ADDRESS
-API_HOST=http://localhost:3000/api
-```
+You can modify these entries in file .env accordingly.
 
 ### Run TangleID
 - [x] Build and launch TangleID service

--- a/next.config.js
+++ b/next.config.js
@@ -4,7 +4,8 @@ const webpack = require('webpack');
 const customEnvironments = dotenv.config().parsed;
 
 const defaultEnvironments = {
-  BACKEND: 'http://node2.puyuma.org:8000',
+  IRI_HOST: 'http://node2.puyuma.org:8000',
+  SWARM_HOST: 'http://node2.puyuma.org:8000',
   API_HOST: 'http://localhost:3000/api',
 };
 

--- a/server.js
+++ b/server.js
@@ -26,8 +26,9 @@ app.prepare()
     const server = express();
     server.use(express.json());
 
+    // forward request to the swarm-node that implement the full-feature TangleID API
     server.all('/api/proxy/*', (req, res) => {
-      proxy.web(req, res, { target: process.env.BACKEND });
+      proxy.web(req, res, { target: process.env.SWARM_HOST });
     });
 
 

--- a/utils/iotaSetup.js
+++ b/utils/iotaSetup.js
@@ -1,6 +1,6 @@
 const IOTA = require('iota.lib.js');
 
-const defaultNode = process.env.BACKEND;
+const defaultNode = process.env.IRI_HOST;
 const iota = new IOTA({
   provider: defaultNode,
 });


### PR DESCRIPTION
Since we are using the 'BACKEND' identifier in the IOTA library API
and the 'TangleidAPI' for the different purpose.

To eliminate misleading environment variable, separate it into two
identifiers and clarified as follows:
* IRI_HOST: an address (IP or domain) to the IRI node.
* SWARM_HOST: an address (IP or domain) to the swarm node that
implement the TangleID API.