### PR TITLE
Allow using unary ++ and -- operators

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -19,6 +19,7 @@ module.exports = {
   "rules": {
     "no-console": ["error", { allow: [ "log", "warn", "error" ] }],
     "no-restricted-syntax": [0], // allow using JavaScript features and syntax
+    "no-plusplus": [0], // allow using ++ and -- operators
     "no-param-reassign": ["error", { "props": false }], // allow to modify parameter properties
     "react/jsx-filename-extension": [1, { "extensions": [".js", ".jsx"] }],
     "react/forbid-prop-types": [0],

--- a/STYLE-GUIDE.md
+++ b/STYLE-GUIDE.md
@@ -1,5 +1,7 @@
-### Refer to Airbnb JavaScript Style Guide
-  - https://github.com/airbnb/javascript
+## Style Guide
+
+Most of our coding style is following the [Airbnb JavaScript Style Guide](https://github.com/airbnb/javascript),
+but some of the rules are changed for the following reason.
 
 ### Allow the unary operators ++ and --
 

--- a/STYLE-GUIDE.md
+++ b/STYLE-GUIDE.md
@@ -1,6 +1,24 @@
 ### Refer to Airbnb JavaScript Style Guide
   - https://github.com/airbnb/javascript
 
+### Allow the unary operators ++ and --
+
+Since we are using semicolons instead of ASI, it would be fine to use
+++ and -- operators without any side effect.
+
+```javascript
+var foo = 0;
+foo++;
+
+var bar = 42;
+bar--;
+
+for (i = 0; i < l; i++) {
+  return;
+}
+```
+
+## Code example
 
 ### Writing the React Component
 Class-based components are preferable over the ones in pure function,


### PR DESCRIPTION
Because the unary ++ and -- operators are subject to automatic
semicolon insertion(ASI), differences in white space can change the
semantics of source code.

Since we are using semicolons instead of ASI, it should be okay to use
these operators without any side effect.

By disabling the "no-plusplus" rule to use the unary ++ and --
operators.