### PR TITLE
Ensure package dependency with Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+language: node_js
+node_js:
+  - "10"
+  - "lts/*"
+
+script:
+  - echo "Skip unit test"


### PR DESCRIPTION
Because the NPM package may not compatible with the different version
of Node.js, it could be failed to install package dependencies(#14).

Travis CI is a continuous integration service used to build and test
projects hosted at GitHub.

To eliminate this problem, set up the Travis CI to check dependencies
when each code base changes with following Node.js version:
 * 10
 * LTS

Since we don't have the unit test yet, so skip it.

See also: #41