### PR TITLE
Remove shortcut variables

### DIFF
--- a/pages/users/new.js
+++ b/pages/users/new.js
@@ -7,7 +7,7 @@ import configureStore from '../../store/configureStore';
 import updateLocalAccount from '../../actions/updateLocalAccount';
 import Layout from '../../layouts/material/Main';
 import NewUserForm from '../../components/NewUserForm';
-import createKeyPair from '../../utils/createKeyPair';
+import { generateKeyPair } from '../../utils/tools';
 import tangleid from '../../utils/tangleidSetup';
 
 const generateUUID = () => {
@@ -21,7 +21,7 @@ class NewUserPage extends Component {
   constructor() {
     super();
     const uuid = generateUUID();
-    const keyPairs = createKeyPair();
+    const keyPairs = generateKeyPair();
 
     this.state = {
       uuid, keyPairs,

--- a/utils/createKeyPair.js
+++ b/utils/createKeyPair.js
@@ -1,9 +1,0 @@
-const forge = require('node-forge');
-
-module.exports = function createKeyPair() {
-  const rsa = forge.pki.rsa;
-  const keypair = rsa.generateKeyPair({ bits: 2048, e: 0x10001 });
-  const pk = forge.pki.publicKeyToPem(keypair.publicKey);
-  const sk = forge.pki.privateKeyToPem(keypair.privateKey);
-  return { sk, pk };
-};

--- a/utils/tools.js
+++ b/utils/tools.js
@@ -7,11 +7,11 @@ const dUTF = data => forge.util.decodeUtf8(data);
 const eUTF = data => forge.util.encodeUtf8(data);
 
 const generateKeyPair = () => {
-  const rsa = forge.pki.rsa;
-  const keypair = rsa.generateKeyPair({ bits: 2048, e: 0x10001 });
-  const pk = forge.pki.publicKeyToPem(keypair.publicKey);
-  const sk = forge.pki.privateKeyToPem(keypair.privateKey);
-  return { sk, pk };
+  const keypair = forge.pki.rsa.generateKeyPair({ bits: 2048, e: 0x10001 });
+  return {
+    pk: forge.pki.publicKeyToPem(keypair.publicKey),
+    sk: forge.pki.privateKeyToPem(keypair.privateKey),
+  };
 };
 
 const seedGen = (length) => {

--- a/utils/tools.js
+++ b/utils/tools.js
@@ -9,8 +9,8 @@ const eUTF = data => forge.util.encodeUtf8(data);
 const generateKeyPair = () => {
   const rsa = forge.pki.rsa;
   const keypair = rsa.generateKeyPair({ bits: 2048, e: 0x10001 });
-  const pk = e64(forge.pki.publicKeyToPem(keypair.publicKey));
-  const sk = e64(forge.pki.privateKeyToPem(keypair.privateKey));
+  const pk = forge.pki.publicKeyToPem(keypair.publicKey);
+  const sk = forge.pki.privateKeyToPem(keypair.privateKey);
   return { sk, pk };
 };
 


### PR DESCRIPTION
To increase the code readability, remove the variables that are
used as shortcuts.