### PR TITLE
Fix mam client not mocked

### DIFF
--- a/packages/did/package-lock.json
+++ b/packages/did/package-lock.json
@@ -5,214 +5,129 @@
   "requires": true,
   "dependencies": {
     "@iota/bundle": {
-      "version": "1.0.0-beta.6",
-      "resolved": "https://registry.npmjs.org/@iota/bundle/-/bundle-1.0.0-beta.6.tgz",
-      "integrity": "sha512-4gRGYt0i2Lw7aDWxETvu3k0VkHOpAvSJqoHD2KVAvbjaMkAl+4PCrfqInckCsMgXz21HfKnXc39ZtnanArWcCQ==",
+      "version": "1.0.0-beta.11",
+      "resolved": "https://registry.npmjs.org/@iota/bundle/-/bundle-1.0.0-beta.11.tgz",
+      "integrity": "sha512-H2lau08OJUOGH3pGbTiFoeK9Mx6BiXMCXf0D8f1VbhMN9VgTAZmIHMy2V8LLi8+Zui9O9gcHlert5+17ynYMXA==",
       "requires": {
-        "@iota/converter": "^1.0.0-beta.6",
-        "@iota/kerl": "^1.0.0-beta.6",
-        "@iota/pad": "^1.0.0-beta.6",
-        "@iota/signing": "^1.0.0-beta.6"
+        "@iota/converter": "^1.0.0-beta.11",
+        "@iota/kerl": "^1.0.0-beta.11",
+        "@iota/pad": "^1.0.0-beta.11",
+        "@iota/signing": "^1.0.0-beta.11"
       }
     },
     "@iota/bundle-validator": {
-      "version": "1.0.0-beta.6",
-      "resolved": "https://registry.npmjs.org/@iota/bundle-validator/-/bundle-validator-1.0.0-beta.6.tgz",
-      "integrity": "sha512-ODZJqQ/Dt6AYmCOjsMFo1zYX8MtaMa2xcBdKJr7u/legUgToW5XPwf1ZtInmve4ikCYt+h4JyEq1NxfN+XACcg==",
+      "version": "1.0.0-beta.11",
+      "resolved": "https://registry.npmjs.org/@iota/bundle-validator/-/bundle-validator-1.0.0-beta.11.tgz",
+      "integrity": "sha512-7OijzSNit92k0UwedQgbdAwUe7lyI2FxwMb82EGLEkrC4eQ09RJbu3f0JXLzKubUmzjwUlYGbzrGGC1AHW8cmA==",
       "requires": {
-        "@iota/converter": "^1.0.0-beta.6",
-        "@iota/kerl": "^1.0.0-beta.6",
-        "@iota/signing": "^1.0.0-beta.6",
-        "@iota/transaction": "^1.0.0-beta.6",
-        "@iota/transaction-converter": "^1.0.0-beta.6"
+        "@iota/converter": "^1.0.0-beta.11",
+        "@iota/kerl": "^1.0.0-beta.11",
+        "@iota/signing": "^1.0.0-beta.11",
+        "@iota/transaction": "^1.0.0-beta.11",
+        "@iota/transaction-converter": "^1.0.0-beta.11"
       }
     },
     "@iota/checksum": {
-      "version": "1.0.0-beta.6",
-      "resolved": "https://registry.npmjs.org/@iota/checksum/-/checksum-1.0.0-beta.6.tgz",
-      "integrity": "sha512-yCMd4+yMTqAtr0DYrFjdhiF9+1m/aFwC5gZk/mm+LV1cWe3THK4MMSAOQrC1MfUP8Wjv29tcrkhnKMRuuvUpAw==",
+      "version": "1.0.0-beta.11",
+      "resolved": "https://registry.npmjs.org/@iota/checksum/-/checksum-1.0.0-beta.11.tgz",
+      "integrity": "sha512-u2WR1kBAAJMoY68CGxnURr36nBz/DSKqqWgNfT9LdG3LI/Ai2CbAPUBdfZ0qKo3Z3HK9psyCyHgk6NDGyz8n6g==",
       "requires": {
-        "@iota/converter": "^1.0.0-beta.6",
-        "@iota/kerl": "^1.0.0-beta.6"
+        "@iota/converter": "^1.0.0-beta.11",
+        "@iota/kerl": "^1.0.0-beta.11"
       }
     },
     "@iota/converter": {
-      "version": "1.0.0-beta.6",
-      "resolved": "https://registry.npmjs.org/@iota/converter/-/converter-1.0.0-beta.6.tgz",
-      "integrity": "sha512-qrOFb615AFhJOoC5MEJMKqy5Ud0xHBhBXRhvMK2ma6unZRrTCmZlRtAGyPtqMDrBT6WpMLSjHXtVfGlkav9RWA=="
+      "version": "1.0.0-beta.11",
+      "resolved": "https://registry.npmjs.org/@iota/converter/-/converter-1.0.0-beta.11.tgz",
+      "integrity": "sha512-euKqd0z3So/c0dz0obOcfXhJfB1riZd2nal5oM/R7uW63e4MZUP0A0libbPzGe4iHGX9XqkfAV6j2bhMdzkCFQ=="
     },
     "@iota/core": {
-      "version": "1.0.0-beta.6",
-      "resolved": "https://registry.npmjs.org/@iota/core/-/core-1.0.0-beta.6.tgz",
-      "integrity": "sha512-7L95vqn6yRS5LBwO0LgFC0fEI+3YkGenO+Jtf55k7QpDL5YWGtYrHcwx+BUz+1E+w07XPZ5AqTzmcpY4ljfLaQ==",
+      "version": "1.0.0-beta.11",
+      "resolved": "https://registry.npmjs.org/@iota/core/-/core-1.0.0-beta.11.tgz",
+      "integrity": "sha512-9HARB/wLPmimc9p0Nd2DWOZwFOIML3AB+7dwoS58beZ2XC0ERvfYid5vPTOahWaUfBdDZOGaDYmcISnhfBJXoA==",
       "requires": {
-        "@iota/bundle": "^1.0.0-beta.6",
-        "@iota/bundle-validator": "^1.0.0-beta.6",
-        "@iota/checksum": "^1.0.0-beta.6",
-        "@iota/converter": "^1.0.0-beta.6",
-        "@iota/curl": "^1.0.0-beta.6",
-        "@iota/http-client": "^1.0.0-beta.6",
-        "@iota/kerl": "^1.0.0-beta.6",
-        "@iota/pad": "^1.0.0-beta.6",
-        "@iota/signing": "^1.0.0-beta.6",
-        "@iota/transaction": "^1.0.0-beta.6",
-        "@iota/transaction-converter": "^1.0.0-beta.6",
-        "@types/bluebird": "^3.5.24",
+        "@iota/bundle": "^1.0.0-beta.11",
+        "@iota/bundle-validator": "^1.0.0-beta.11",
+        "@iota/checksum": "^1.0.0-beta.11",
+        "@iota/converter": "^1.0.0-beta.11",
+        "@iota/curl": "^1.0.0-beta.11",
+        "@iota/http-client": "^1.0.0-beta.11",
+        "@iota/kerl": "^1.0.0-beta.11",
+        "@iota/pad": "^1.0.0-beta.11",
+        "@iota/signing": "^1.0.0-beta.11",
+        "@iota/transaction": "^1.0.0-beta.11",
+        "@iota/transaction-converter": "^1.0.0-beta.11",
+        "@types/bluebird": "^3.5.25",
         "bluebird": "^3.5.1"
       }
     },
     "@iota/curl": {
-      "version": "1.0.0-beta.6",
-      "resolved": "https://registry.npmjs.org/@iota/curl/-/curl-1.0.0-beta.6.tgz",
-      "integrity": "sha512-KUqqIBncJYuKT0DYwLl6GiGwZcHHmOGhkxwimOKCavmAdoYNWAzygianojPWECZkzMstgxhorLhSM8EE0xtTKQ=="
+      "version": "1.0.0-beta.11",
+      "resolved": "https://registry.npmjs.org/@iota/curl/-/curl-1.0.0-beta.11.tgz",
+      "integrity": "sha512-b2+/S8YBGsr3beX9tg5etKItlbN7rpDIDjDnBRPsqvD9BmFyvcJe/2HxAyPeob/rPuZYoPgFw4OrdDw7ym/sZQ=="
     },
     "@iota/http-client": {
-      "version": "1.0.0-beta.6",
-      "resolved": "https://registry.npmjs.org/@iota/http-client/-/http-client-1.0.0-beta.6.tgz",
-      "integrity": "sha512-+ErMfi46X/jSb19cHoExCi22fa9QXK5CP8tDt682F0PJMHxUf/rZcHJv1ZBbJiRy3OMUbidi8m0n+/Dsj6qAtg==",
+      "version": "1.0.0-beta.11",
+      "resolved": "https://registry.npmjs.org/@iota/http-client/-/http-client-1.0.0-beta.11.tgz",
+      "integrity": "sha512-GsNCqUoHXmxWymnVDejderHvcACtKOOLPJjq8IMAxMBw/MCaxjlIgnMqMKvpeY/7f8gQQBEbBgnyekoHVYsM9g==",
       "requires": {
-        "@types/bluebird": "^3.5.24",
+        "@types/bluebird": "^3.5.25",
         "bluebird": "^3.5.1",
-        "cross-fetch": "^2.2.2"
+        "cross-fetch": "^3.0.0"
       }
     },
     "@iota/kerl": {
-      "version": "1.0.0-beta.6",
-      "resolved": "https://registry.npmjs.org/@iota/kerl/-/kerl-1.0.0-beta.6.tgz",
-      "integrity": "sha512-Fu7QgDxFtX1zG4NbI6PJpMSk+uFYLkkmRos49uxG1kG2PFHRy3Kufa7HJqT2jXKoEEVWxHiTHkJiFO95x0riew==",
+      "version": "1.0.0-beta.11",
+      "resolved": "https://registry.npmjs.org/@iota/kerl/-/kerl-1.0.0-beta.11.tgz",
+      "integrity": "sha512-Yut/cl5xiBUA4wtVctgJDWtRltahSfLN8sWmRLQF7uqL/qngCRZ7iVtUehyPuXR4UlVzqU1kV/uMeuHKth2bWw==",
       "requires": {
         "@types/crypto-js": "^3.1.38",
         "crypto-js": "^3.1.9-1"
       }
     },
     "@iota/pad": {
-      "version": "1.0.0-beta.6",
-      "resolved": "https://registry.npmjs.org/@iota/pad/-/pad-1.0.0-beta.6.tgz",
-      "integrity": "sha512-O+KfdRG6n1004r1laS/K4BBl8iDnEOCl+rDK3vhEbmcJr6lxzUZPrra5dSjjQW0FrGngSjhKS/m9xHF7nfzarg=="
+      "version": "1.0.0-beta.11",
+      "resolved": "https://registry.npmjs.org/@iota/pad/-/pad-1.0.0-beta.11.tgz",
+      "integrity": "sha512-1e6ujEhKbtk4jB+Y0Hlbg48DvdDjvbU8RUST3IrOK1NekFKVoU9KQBxm3o3RVyxos+2KPIzHddyOYbSyOIyFrw=="
     },
     "@iota/signing": {
-      "version": "1.0.0-beta.6",
-      "resolved": "https://registry.npmjs.org/@iota/signing/-/signing-1.0.0-beta.6.tgz",
-      "integrity": "sha512-6F6df9yoGrUlcNdS3QxKkBMleF39jRcVtcgZ6pVBh30h0UmyPh1gg7EZ6PCqAJ6tdXJ39JGpJdLiKObbAybVcw==",
+      "version": "1.0.0-beta.11",
+      "resolved": "https://registry.npmjs.org/@iota/signing/-/signing-1.0.0-beta.11.tgz",
+      "integrity": "sha512-pzYNQboly9TcgYoVO5xk8xBaQV084CrTKG+tFwlvnFUZEua9J73GBSQmmlg63R1AyC7oOPmV0yuxyT3CWdKUzw==",
       "requires": {
-        "@iota/converter": "^1.0.0-beta.6",
-        "@iota/kerl": "^1.0.0-beta.6",
-        "@iota/pad": "^1.0.0-beta.6"
+        "@iota/converter": "^1.0.0-beta.11",
+        "@iota/kerl": "^1.0.0-beta.11",
+        "@iota/pad": "^1.0.0-beta.11"
       }
     },
     "@iota/transaction": {
-      "version": "1.0.0-beta.6",
-      "resolved": "https://registry.npmjs.org/@iota/transaction/-/transaction-1.0.0-beta.6.tgz",
-      "integrity": "sha512-Ieife+MGtuZrjBNHiW3qaPwwf/XuLvXg4OUHgO20j1c4sY1131Vexo4yNdiyNPLgkAex/9ihIdsxZ+hx3rVtrw==",
+      "version": "1.0.0-beta.11",
+      "resolved": "https://registry.npmjs.org/@iota/transaction/-/transaction-1.0.0-beta.11.tgz",
+      "integrity": "sha512-fXQSjb169vF61d7tvzKQbbCl+rWVHoxy9kTg+OSwLnEDCh/36iEgVh1u+PyudzzyBzP5r3dbwJRZa95N8HGscw==",
       "requires": {
-        "@iota/converter": "^1.0.0-beta.6",
-        "@iota/curl": "^1.0.0-beta.6"
+        "@iota/converter": "^1.0.0-beta.11",
+        "@iota/curl": "^1.0.0-beta.11"
       }
     },
     "@iota/transaction-converter": {
-      "version": "1.0.0-beta.6",
-      "resolved": "https://registry.npmjs.org/@iota/transaction-converter/-/transaction-converter-1.0.0-beta.6.tgz",
-      "integrity": "sha512-loE3bYFpAF+il1YhDhS+JZvWZXsg+yLyhmhsTGlf89pNC5ejk+9ebsdYYMdHdHyd7GB1h3h+8m4sLy/bmcXcSA==",
+      "version": "1.0.0-beta.11",
+      "resolved": "https://registry.npmjs.org/@iota/transaction-converter/-/transaction-converter-1.0.0-beta.11.tgz",
+      "integrity": "sha512-ba/G9U8Z+er3C9SYPejxYqS/tHf7pxaCn+F0lJm5K9wd1dcHAb1F2tGsub+88J4lwZrHsrhhhMQSqf1nooNE5A==",
       "requires": {
-        "@iota/converter": "^1.0.0-beta.6",
-        "@iota/pad": "^1.0.0-beta.6",
-        "@iota/transaction": "^1.0.0-beta.6"
+        "@iota/converter": "^1.0.0-beta.11",
+        "@iota/pad": "^1.0.0-beta.11",
+        "@iota/transaction": "^1.0.0-beta.11"
       }
     },
     "@types/bluebird": {
-      "version": "3.5.24",
-      "resolved": "https://registry.npmjs.org/@types/bluebird/-/bluebird-3.5.24.tgz",
-      "integrity": "sha512-YeQoDpq4Lm8ppSBqAnAeF/xy1cYp/dMTif2JFcvmAbETMRlvKHT2iLcWu+WyYiJO3b3Ivokwo7EQca/xfLVJmg=="
+      "version": "3.5.26",
+      "resolved": "https://registry.npmjs.org/@types/bluebird/-/bluebird-3.5.26.tgz",
+      "integrity": "sha512-aj2mrBLn5ky0GmAg6IPXrQjnN0iB/ulozuJ+oZdrHRAzRbXjGmu4UXsNCjFvPbSaaPZmniocdOzsM392qLOlmQ=="
     },
     "@types/crypto-js": {
       "version": "3.1.43",
       "resolved": "https://registry.npmjs.org/@types/crypto-js/-/crypto-js-3.1.43.tgz",
       "integrity": "sha512-EHe/YKctU3IYNBsDmSOPX/7jLHPRlx8WaiDKSY9JCTnJ8XJeM4c0ZJvx+9Gxmr2s2ihI92R+3U/gNL1sq5oRuQ=="
-    },
-    "JSONStream": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.5.tgz",
-      "integrity": "sha512-E+iruNOY8VV9s4JEbe1aNEm6MiszPRr/UfcHMz0TQh1BXSxHK+ASV1R6W4HpjBhSeS+54PIsAMCBmwD06LLsqQ==",
-      "requires": {
-        "jsonparse": "^1.2.0",
-        "through": ">=2.2.7 <3"
-      }
-    },
-    "acorn-dynamic-import": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/acorn-dynamic-import/-/acorn-dynamic-import-4.0.0.tgz",
-      "integrity": "sha512-d3OEjQV4ROpoflsnUA8HozoIR504TFxNivYEUi6uwz0IYhBkTDXGuWlNdMtybRt3nqVx/L6XqMt0FxkXuWKZhw=="
-    },
-    "acorn-node": {
-      "version": "1.6.2",
-      "resolved": "https://registry.npmjs.org/acorn-node/-/acorn-node-1.6.2.tgz",
-      "integrity": "sha512-rIhNEZuNI8ibQcL7ANm/mGyPukIaZsRNX9psFNQURyJW0nu6k8wjSDld20z6v2mDBWqX13pIEnk9gGZJHIlEXg==",
-      "requires": {
-        "acorn": "^6.0.2",
-        "acorn-dynamic-import": "^4.0.0",
-        "acorn-walk": "^6.1.0",
-        "xtend": "^4.0.1"
-      },
-      "dependencies": {
-        "acorn": {
-          "version": "6.0.4",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.0.4.tgz",
-          "integrity": "sha512-VY4i5EKSKkofY2I+6QLTbTTN/UvEQPCo6eiwzzSaSWfpaDhOmStMCMod6wmuPciNq+XS0faCglFu2lHZpdHUtg=="
-        }
-      }
-    },
-    "acorn-walk": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-6.1.0.tgz",
-      "integrity": "sha512-ugTb7Lq7u4GfWSqqpwE0bGyoBZNMTok/zDBXxfEG0QM50jNlGhIWjRC1pPN7bvV1anhF+bs+/gNcRw+o55Evbg=="
-    },
-    "array-filter": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/array-filter/-/array-filter-0.0.1.tgz",
-      "integrity": "sha1-fajPLiZijtcygDWB/SH2fKzS7uw="
-    },
-    "array-map": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/array-map/-/array-map-0.0.0.tgz",
-      "integrity": "sha1-iKK6tz0c97zVwbEYoAP2b2ZfpmI="
-    },
-    "array-reduce": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/array-reduce/-/array-reduce-0.0.0.tgz",
-      "integrity": "sha1-FziZ0//Rx9k4PkR5Ul2+J4yrXys="
-    },
-    "asn1.js": {
-      "version": "4.10.1",
-      "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.10.1.tgz",
-      "integrity": "sha512-p32cOF5q0Zqs9uBiONKYLm6BClCoBCM5O9JfeUSlnQLBTxYdTK+pW+nXflm8UkKd2UYlEbYz5qEi0JuZR9ckSw==",
-      "requires": {
-        "bn.js": "^4.0.0",
-        "inherits": "^2.0.1",
-        "minimalistic-assert": "^1.0.0"
-      }
-    },
-    "assert": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/assert/-/assert-1.4.1.tgz",
-      "integrity": "sha1-mZEtWRg2tab1s0XA8H7vwI/GXZE=",
-      "requires": {
-        "util": "0.10.3"
-      },
-      "dependencies": {
-        "inherits": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-          "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE="
-        },
-        "util": {
-          "version": "0.10.3",
-          "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
-          "integrity": "sha1-evsa/lCAUkZInj23/g7TeTNqwPk=",
-          "requires": {
-            "inherits": "2.0.1"
-          }
-        }
-      }
     },
     "async": {
       "version": "2.6.1",
@@ -248,11 +163,6 @@
         "regenerator-runtime": "^0.11.0"
       }
     },
-    "balanced-match": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
-    },
     "base-x": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.4.tgz",
@@ -276,173 +186,6 @@
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.3.tgz",
       "integrity": "sha512-/qKPUQlaW1OyR51WeCPBvRnAlnZFUJkCSG5HzGnuIqhgyJtF+T94lFnn33eiazjRm2LAHVy2guNnaq48X9SJuw=="
     },
-    "bn.js": {
-      "version": "4.11.8",
-      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
-      "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA=="
-    },
-    "brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-      "requires": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
-    "brorand": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
-      "integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8="
-    },
-    "browser-pack": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/browser-pack/-/browser-pack-6.1.0.tgz",
-      "integrity": "sha512-erYug8XoqzU3IfcU8fUgyHqyOXqIE4tUTTQ+7mqUjQlvnXkOO6OlT9c/ZoJVHYoAaqGxr09CN53G7XIsO4KtWA==",
-      "requires": {
-        "JSONStream": "^1.0.3",
-        "combine-source-map": "~0.8.0",
-        "defined": "^1.0.0",
-        "safe-buffer": "^5.1.1",
-        "through2": "^2.0.0",
-        "umd": "^3.0.0"
-      }
-    },
-    "browser-resolve": {
-      "version": "1.11.3",
-      "resolved": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.11.3.tgz",
-      "integrity": "sha512-exDi1BYWB/6raKHmDTCicQfTkqwN5fioMFV4j8BsfMU4R2DK/QfZfK7kOVkmWCNANf0snkBzqGqAJBao9gZMdQ==",
-      "requires": {
-        "resolve": "1.1.7"
-      }
-    },
-    "browserify": {
-      "version": "16.2.3",
-      "resolved": "https://registry.npmjs.org/browserify/-/browserify-16.2.3.tgz",
-      "integrity": "sha512-zQt/Gd1+W+IY+h/xX2NYMW4orQWhqSwyV+xsblycTtpOuB27h1fZhhNQuipJ4t79ohw4P4mMem0jp/ZkISQtjQ==",
-      "requires": {
-        "JSONStream": "^1.0.3",
-        "assert": "^1.4.0",
-        "browser-pack": "^6.0.1",
-        "browser-resolve": "^1.11.0",
-        "browserify-zlib": "~0.2.0",
-        "buffer": "^5.0.2",
-        "cached-path-relative": "^1.0.0",
-        "concat-stream": "^1.6.0",
-        "console-browserify": "^1.1.0",
-        "constants-browserify": "~1.0.0",
-        "crypto-browserify": "^3.0.0",
-        "defined": "^1.0.0",
-        "deps-sort": "^2.0.0",
-        "domain-browser": "^1.2.0",
-        "duplexer2": "~0.1.2",
-        "events": "^2.0.0",
-        "glob": "^7.1.0",
-        "has": "^1.0.0",
-        "htmlescape": "^1.1.0",
-        "https-browserify": "^1.0.0",
-        "inherits": "~2.0.1",
-        "insert-module-globals": "^7.0.0",
-        "labeled-stream-splicer": "^2.0.0",
-        "mkdirp": "^0.5.0",
-        "module-deps": "^6.0.0",
-        "os-browserify": "~0.3.0",
-        "parents": "^1.0.1",
-        "path-browserify": "~0.0.0",
-        "process": "~0.11.0",
-        "punycode": "^1.3.2",
-        "querystring-es3": "~0.2.0",
-        "read-only-stream": "^2.0.0",
-        "readable-stream": "^2.0.2",
-        "resolve": "^1.1.4",
-        "shasum": "^1.0.0",
-        "shell-quote": "^1.6.1",
-        "stream-browserify": "^2.0.0",
-        "stream-http": "^2.0.0",
-        "string_decoder": "^1.1.1",
-        "subarg": "^1.0.0",
-        "syntax-error": "^1.1.1",
-        "through2": "^2.0.0",
-        "timers-browserify": "^1.0.1",
-        "tty-browserify": "0.0.1",
-        "url": "~0.11.0",
-        "util": "~0.10.1",
-        "vm-browserify": "^1.0.0",
-        "xtend": "^4.0.0"
-      },
-      "dependencies": {
-        "punycode": {
-          "version": "1.4.1",
-          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-          "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
-        }
-      }
-    },
-    "browserify-aes": {
-      "version": "1.2.0",
-      "resolved": "http://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
-      "integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
-      "requires": {
-        "buffer-xor": "^1.0.3",
-        "cipher-base": "^1.0.0",
-        "create-hash": "^1.1.0",
-        "evp_bytestokey": "^1.0.3",
-        "inherits": "^2.0.1",
-        "safe-buffer": "^5.0.1"
-      }
-    },
-    "browserify-cipher": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/browserify-cipher/-/browserify-cipher-1.0.1.tgz",
-      "integrity": "sha512-sPhkz0ARKbf4rRQt2hTpAHqn47X3llLkUGn+xEJzLjwY8LRs2p0v7ljvI5EyoRO/mexrNunNECisZs+gw2zz1w==",
-      "requires": {
-        "browserify-aes": "^1.0.4",
-        "browserify-des": "^1.0.0",
-        "evp_bytestokey": "^1.0.0"
-      }
-    },
-    "browserify-des": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/browserify-des/-/browserify-des-1.0.2.tgz",
-      "integrity": "sha512-BioO1xf3hFwz4kc6iBhI3ieDFompMhrMlnDFC4/0/vd5MokpuAc3R+LYbwTA9A5Yc9pq9UYPqffKpW2ObuwX5A==",
-      "requires": {
-        "cipher-base": "^1.0.1",
-        "des.js": "^1.0.0",
-        "inherits": "^2.0.1",
-        "safe-buffer": "^5.1.2"
-      }
-    },
-    "browserify-rsa": {
-      "version": "4.0.1",
-      "resolved": "http://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
-      "integrity": "sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=",
-      "requires": {
-        "bn.js": "^4.1.0",
-        "randombytes": "^2.0.1"
-      }
-    },
-    "browserify-sign": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.0.4.tgz",
-      "integrity": "sha1-qk62jl17ZYuqa/alfmMMvXqT0pg=",
-      "requires": {
-        "bn.js": "^4.1.1",
-        "browserify-rsa": "^4.0.0",
-        "create-hash": "^1.1.0",
-        "create-hmac": "^1.1.2",
-        "elliptic": "^6.0.0",
-        "inherits": "^2.0.1",
-        "parse-asn1": "^5.0.0"
-      }
-    },
-    "browserify-zlib": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.2.0.tgz",
-      "integrity": "sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==",
-      "requires": {
-        "pako": "~1.0.5"
-      }
-    },
     "buffer": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.2.0.tgz",
@@ -450,35 +193,6 @@
       "requires": {
         "base64-js": "^1.0.2",
         "ieee754": "^1.1.4"
-      }
-    },
-    "buffer-from": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
-      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A=="
-    },
-    "buffer-xor": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
-      "integrity": "sha1-JuYe0UIvtw3ULm42cp7VHYVf6Nk="
-    },
-    "builtin-status-codes": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz",
-      "integrity": "sha1-hZgoeOIbmOHGZCXgPQF0eI9Wnug="
-    },
-    "cached-path-relative": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/cached-path-relative/-/cached-path-relative-1.0.2.tgz",
-      "integrity": "sha512-5r2GqsoEb4qMTTN9J+WzXfjov+hjxT+j3u5K+kIVNIwAd99DLCJE9pBIMP1qVeybV6JiijL385Oz0DcYxfbOIg=="
-    },
-    "cipher-base": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
-      "integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
-      "requires": {
-        "inherits": "^2.0.1",
-        "safe-buffer": "^5.0.1"
       }
     },
     "color": {
@@ -531,53 +245,6 @@
         "text-hex": "1.0.x"
       }
     },
-    "combine-source-map": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/combine-source-map/-/combine-source-map-0.8.0.tgz",
-      "integrity": "sha1-pY0N8ELBhvz4IqjoAV9UUNLXmos=",
-      "requires": {
-        "convert-source-map": "~1.1.0",
-        "inline-source-map": "~0.6.0",
-        "lodash.memoize": "~3.0.3",
-        "source-map": "~0.5.3"
-      },
-      "dependencies": {
-        "convert-source-map": {
-          "version": "1.1.3",
-          "resolved": "http://registry.npmjs.org/convert-source-map/-/convert-source-map-1.1.3.tgz",
-          "integrity": "sha1-SCnId+n+SbMWHzvzZziI4gRpmGA="
-        }
-      }
-    },
-    "concat-map": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
-    },
-    "concat-stream": {
-      "version": "1.6.2",
-      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
-      "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
-      "requires": {
-        "buffer-from": "^1.0.0",
-        "inherits": "^2.0.3",
-        "readable-stream": "^2.2.2",
-        "typedarray": "^0.0.6"
-      }
-    },
-    "console-browserify": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
-      "integrity": "sha1-8CQcRXMKn8YyOyBtvzjtx0HQuxA=",
-      "requires": {
-        "date-now": "^0.1.4"
-      }
-    },
-    "constants-browserify": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-1.0.0.tgz",
-      "integrity": "sha1-wguW2MYXdIqvHBYCF2DNJ/y4y3U="
-    },
     "core-js": {
       "version": "2.5.7",
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.7.tgz",
@@ -588,118 +255,19 @@
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
     },
-    "create-ecdh": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.3.tgz",
-      "integrity": "sha512-GbEHQPMOswGpKXM9kCWVrremUcBmjteUaQ01T9rkKCPDXfUHX0IoP9LpHYo2NPFampa4e+/pFDc3jQdxrxQLaw==",
-      "requires": {
-        "bn.js": "^4.1.0",
-        "elliptic": "^6.0.0"
-      }
-    },
-    "create-hash": {
-      "version": "1.2.0",
-      "resolved": "http://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
-      "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
-      "requires": {
-        "cipher-base": "^1.0.1",
-        "inherits": "^2.0.1",
-        "md5.js": "^1.3.4",
-        "ripemd160": "^2.0.1",
-        "sha.js": "^2.4.0"
-      }
-    },
-    "create-hmac": {
-      "version": "1.1.7",
-      "resolved": "http://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
-      "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
-      "requires": {
-        "cipher-base": "^1.0.3",
-        "create-hash": "^1.1.0",
-        "inherits": "^2.0.1",
-        "ripemd160": "^2.0.0",
-        "safe-buffer": "^5.0.1",
-        "sha.js": "^2.4.8"
-      }
-    },
     "cross-fetch": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-2.2.3.tgz",
-      "integrity": "sha512-PrWWNH3yL2NYIb/7WF/5vFG3DCQiXDOVf8k3ijatbrtnwNuhMWLC7YF7uqf53tbTFDzHIUD8oITw4Bxt8ST3Nw==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.0.1.tgz",
+      "integrity": "sha512-qWtpgBAF8ioqBOddRD+pHhrdzm/UWOArkrlIU7c08DlNbOxo5GfUbSY2vr90ZypWf0raW+HNN1F38pi5CEOjiQ==",
       "requires": {
-        "node-fetch": "2.1.2",
-        "whatwg-fetch": "2.0.4"
-      }
-    },
-    "crypto-browserify": {
-      "version": "3.12.0",
-      "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.12.0.tgz",
-      "integrity": "sha512-fz4spIh+znjO2VjL+IdhEpRJ3YN6sMzITSBijk6FK2UvTqruSQW+/cCZTSNsMiZNvUeq0CqurF+dAbyiGOY6Wg==",
-      "requires": {
-        "browserify-cipher": "^1.0.0",
-        "browserify-sign": "^4.0.0",
-        "create-ecdh": "^4.0.0",
-        "create-hash": "^1.1.0",
-        "create-hmac": "^1.1.0",
-        "diffie-hellman": "^5.0.0",
-        "inherits": "^2.0.1",
-        "pbkdf2": "^3.0.3",
-        "public-encrypt": "^4.0.0",
-        "randombytes": "^2.0.0",
-        "randomfill": "^1.0.3"
+        "node-fetch": "2.3.0",
+        "whatwg-fetch": "3.0.0"
       }
     },
     "crypto-js": {
       "version": "3.1.9-1",
       "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-3.1.9-1.tgz",
       "integrity": "sha1-/aGedh/Ad+Af+/3G6f38WeiAbNg="
-    },
-    "date-now": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz",
-      "integrity": "sha1-6vQ5/U1ISK105cx9vvIAZyueNFs="
-    },
-    "defined": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
-      "integrity": "sha1-yY2bzvdWdBiOEQlpFRGZ45sfppM="
-    },
-    "deps-sort": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/deps-sort/-/deps-sort-2.0.0.tgz",
-      "integrity": "sha1-CRckkC6EZYJg65EHSMzNGvbiH7U=",
-      "requires": {
-        "JSONStream": "^1.0.3",
-        "shasum": "^1.0.0",
-        "subarg": "^1.0.0",
-        "through2": "^2.0.0"
-      }
-    },
-    "des.js": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/des.js/-/des.js-1.0.0.tgz",
-      "integrity": "sha1-wHTS4qpqipoH29YfmhXCzYPsjsw=",
-      "requires": {
-        "inherits": "^2.0.1",
-        "minimalistic-assert": "^1.0.0"
-      }
-    },
-    "detective": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/detective/-/detective-5.1.0.tgz",
-      "integrity": "sha512-TFHMqfOvxlgrfVzTEkNBSh9SvSNX/HfF4OFI2QFGCyPm02EsyILqnUeb5P6q7JZ3SFNTBL5t2sePRgrN4epUWQ==",
-      "requires": {
-        "acorn-node": "^1.3.0",
-        "defined": "^1.0.0",
-        "minimist": "^1.1.1"
-      },
-      "dependencies": {
-        "minimist": {
-          "version": "1.2.0",
-          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
-        }
-      }
     },
     "diagnostics": {
       "version": "1.1.1",
@@ -719,43 +287,6 @@
         "babel-runtime": "^6.26.0"
       }
     },
-    "diffie-hellman": {
-      "version": "5.0.3",
-      "resolved": "http://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
-      "integrity": "sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg==",
-      "requires": {
-        "bn.js": "^4.1.0",
-        "miller-rabin": "^4.0.0",
-        "randombytes": "^2.0.0"
-      }
-    },
-    "domain-browser": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.2.0.tgz",
-      "integrity": "sha512-jnjyiM6eRyZl2H+W8Q/zLMA481hzi0eszAaBUzIVnmYVDBbnLxVNnfu1HgEBvCbL+71FrxMl3E6lpKH7Ge3OXA=="
-    },
-    "duplexer2": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
-      "integrity": "sha1-ixLauHjA1p4+eJEFFmKjL8a93ME=",
-      "requires": {
-        "readable-stream": "^2.0.2"
-      }
-    },
-    "elliptic": {
-      "version": "6.4.1",
-      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.4.1.tgz",
-      "integrity": "sha512-BsXLz5sqX8OHcsh7CqBMztyXARmGQ3LWPtGjJi6DiJHq5C/qvi9P3OqgswKSDftbu8+IoI/QDTAm2fFnQ9SZSQ==",
-      "requires": {
-        "bn.js": "^4.4.0",
-        "brorand": "^1.0.1",
-        "hash.js": "^1.0.0",
-        "hmac-drbg": "^1.0.0",
-        "inherits": "^2.0.1",
-        "minimalistic-assert": "^1.0.0",
-        "minimalistic-crypto-utils": "^1.0.0"
-      }
-    },
     "enabled": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/enabled/-/enabled-1.0.2.tgz",
@@ -768,20 +299,6 @@
       "version": "0.0.5",
       "resolved": "https://registry.npmjs.org/env-variable/-/env-variable-0.0.5.tgz",
       "integrity": "sha512-zoB603vQReOFvTg5xMl9I1P2PnHsHQQKTEowsKKD7nseUfJq6UWzK+4YtlWUO1nhiQUxe6XMkk+JleSZD1NZFA=="
-    },
-    "events": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/events/-/events-2.1.0.tgz",
-      "integrity": "sha512-3Zmiobend8P9DjmKAty0Era4jV8oJ0yGYe2nJJAxgymF9+N8F2m0hhZiMoWtcfepExzNKZumFU3ksdQbInGWCg=="
-    },
-    "evp_bytestokey": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz",
-      "integrity": "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==",
-      "requires": {
-        "md5.js": "^1.3.4",
-        "safe-buffer": "^5.1.1"
-      }
     },
     "extend": {
       "version": "3.0.2",
@@ -798,128 +315,20 @@
       "resolved": "https://registry.npmjs.org/fecha/-/fecha-2.3.3.tgz",
       "integrity": "sha512-lUGBnIamTAwk4znq5BcqsDaxSmZ9nDVJaij6NvRt/Tg4R69gERA+otPKbS86ROw9nxVMw2/mp1fnaiWqbs6Sdg=="
     },
-    "fs.realpath": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
-    },
-    "function-bind": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
-    },
-    "get-assigned-identifiers": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/get-assigned-identifiers/-/get-assigned-identifiers-1.2.0.tgz",
-      "integrity": "sha512-mBBwmeGTrxEMO4pMaaf/uUEFHnYtwr8FTe8Y/mer4rcV/bye0qGm6pw1bGZFGStxC5O76c5ZAVBGnqHmOaJpdQ=="
-    },
-    "glob": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-      "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
-      "requires": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.0.4",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
-      }
-    },
-    "has": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
-      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
-      "requires": {
-        "function-bind": "^1.1.1"
-      }
-    },
     "has-flag": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
       "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
-    },
-    "hash-base": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.0.4.tgz",
-      "integrity": "sha1-X8hoaEfs1zSZQDMZprCj8/auSRg=",
-      "requires": {
-        "inherits": "^2.0.1",
-        "safe-buffer": "^5.0.1"
-      }
-    },
-    "hash.js": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.5.tgz",
-      "integrity": "sha512-eWI5HG9Np+eHV1KQhisXWwM+4EPPYe5dFX1UZZH7k/E3JzDEazVH+VGlZi6R94ZqImq+A3D1mCEtrFIfg/E7sA==",
-      "requires": {
-        "inherits": "^2.0.3",
-        "minimalistic-assert": "^1.0.1"
-      }
-    },
-    "hmac-drbg": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
-      "integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
-      "requires": {
-        "hash.js": "^1.0.3",
-        "minimalistic-assert": "^1.0.0",
-        "minimalistic-crypto-utils": "^1.0.1"
-      }
-    },
-    "htmlescape": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/htmlescape/-/htmlescape-1.1.1.tgz",
-      "integrity": "sha1-OgPtwiFLyjtmQko+eVk0lQnLA1E="
-    },
-    "https-browserify": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-1.0.0.tgz",
-      "integrity": "sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM="
     },
     "ieee754": {
       "version": "1.1.12",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.12.tgz",
       "integrity": "sha512-GguP+DRY+pJ3soyIiGPTvdiVXjZ+DbXOxGpXn3eMvNW4x4irjqXm4wHKscC+TfxSJ0yw/S1F24tqdMNsMZTiLA=="
     },
-    "inflight": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-      "requires": {
-        "once": "^1.3.0",
-        "wrappy": "1"
-      }
-    },
     "inherits": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
       "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
-    },
-    "inline-source-map": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/inline-source-map/-/inline-source-map-0.6.2.tgz",
-      "integrity": "sha1-+Tk0ccGKedFyT4Y/o4tYY3Ct4qU=",
-      "requires": {
-        "source-map": "~0.5.3"
-      }
-    },
-    "insert-module-globals": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/insert-module-globals/-/insert-module-globals-7.2.0.tgz",
-      "integrity": "sha512-VE6NlW+WGn2/AeOMd496AHFYmE7eLKkUY6Ty31k4og5vmA3Fjuwe9v6ifH6Xx/Hz27QvdoMoviw1/pqWRB09Sw==",
-      "requires": {
-        "JSONStream": "^1.0.3",
-        "acorn-node": "^1.5.2",
-        "combine-source-map": "^0.8.0",
-        "concat-stream": "^1.6.1",
-        "is-buffer": "^1.1.0",
-        "path-is-absolute": "^1.0.1",
-        "process": "~0.11.0",
-        "through2": "^2.0.0",
-        "undeclared-identifiers": "^1.1.2",
-        "xtend": "^4.0.0"
-      }
     },
     "iota.lib.js": {
       "version": "0.4.7",
@@ -931,11 +340,6 @@
         "crypto-js": "^3.1.9-1",
         "xmlhttprequest": "^1.8.0"
       }
-    },
-    "is-buffer": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
     },
     "is-stream": {
       "version": "1.1.0",
@@ -952,24 +356,6 @@
       "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.8.0.tgz",
       "integrity": "sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q=="
     },
-    "json-stable-stringify": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-0.0.1.tgz",
-      "integrity": "sha1-YRwj6BTbN1Un34URk9tZ3Sryf0U=",
-      "requires": {
-        "jsonify": "~0.0.0"
-      }
-    },
-    "jsonify": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
-      "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM="
-    },
-    "jsonparse": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
-      "integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA="
-    },
     "kuler": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/kuler/-/kuler-1.0.1.tgz",
@@ -978,32 +364,10 @@
         "colornames": "^1.1.1"
       }
     },
-    "labeled-stream-splicer": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/labeled-stream-splicer/-/labeled-stream-splicer-2.0.1.tgz",
-      "integrity": "sha512-MC94mHZRvJ3LfykJlTUipBqenZz1pacOZEMhhQ8dMGcDHs0SBE5GbsavUXV7YtP3icBW17W0Zy1I0lfASmo9Pg==",
-      "requires": {
-        "inherits": "^2.0.1",
-        "isarray": "^2.0.4",
-        "stream-splicer": "^2.0.0"
-      },
-      "dependencies": {
-        "isarray": {
-          "version": "2.0.4",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.4.tgz",
-          "integrity": "sha512-GMxXOiUirWg1xTKRipM0Ek07rX+ubx4nNVElTJdNLYmNO/2YrDkgJGw9CljXn+r4EWiDQg/8lsRdHyg2PJuUaA=="
-        }
-      }
-    },
     "lodash": {
       "version": "4.17.10",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
       "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
-    },
-    "lodash.memoize": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-3.0.4.tgz",
-      "integrity": "sha1-LcvSwofLwKVcxCMovQxzYVDVPj8="
     },
     "logform": {
       "version": "1.10.0",
@@ -1025,22 +389,13 @@
       }
     },
     "mam.client.js": {
-      "version": "git+ssh://git@github.com/iotaledger/mam.client.js.git#5ccd1facbdd7c428333e18d54ac9de7fe79698bf",
-      "from": "mam.client.js@git+ssh://git@github.com/iotaledger/mam.client.js.git#5ccd1facbdd7c428333e18d54ac9de7fe79698bf",
+      "version": "git+https://git@github.com/iotaledger/mam.client.js.git#3e23dc91d56d63d1c20ad0f1396fd0cac4e3b9aa",
+      "from": "git+https://git@github.com/iotaledger/mam.client.js.git",
       "requires": {
-        "@iota/converter": "^1.0.0-beta.5",
-        "@iota/core": "^1.0.0-beta.5",
-        "@iota/curl": "^1.0.0-beta.5",
-        "babel-polyfill": "^6.26.0",
-        "browserify": "^16.1.1",
-        "pify": "^3.0.0"
-      },
-      "dependencies": {
-        "pify": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
-        }
+        "@iota/converter": "^1.0.0-beta.11",
+        "@iota/core": "^1.0.0-beta.11",
+        "@iota/curl": "^1.0.0-beta.11",
+        "babel-polyfill": "^6.26.0"
       }
     },
     "mam.tools.js": {
@@ -1050,18 +405,157 @@
       "requires": {
         "debug": "^3.1.0",
         "iota.lib.js": "^0.4.7",
-        "mam.client.js": "mam.client.js@git+ssh://git@github.com/iotaledger/mam.client.js.git#5ccd1facbdd7c428333e18d54ac9de7fe79698bf",
+        "mam.client.js": "git+ssh://git@github.com/iotaledger/mam.client.js.git",
         "minimist": "^1.2.0",
         "supports-color": "^5.4.0",
         "winston": "^3.0.0"
       },
       "dependencies": {
+        "@iota/bundle": {
+          "version": "1.0.0-beta.11",
+          "resolved": "https://registry.npmjs.org/@iota/bundle/-/bundle-1.0.0-beta.11.tgz",
+          "integrity": "sha512-H2lau08OJUOGH3pGbTiFoeK9Mx6BiXMCXf0D8f1VbhMN9VgTAZmIHMy2V8LLi8+Zui9O9gcHlert5+17ynYMXA==",
+          "requires": {
+            "@iota/converter": "^1.0.0-beta.11",
+            "@iota/kerl": "^1.0.0-beta.11",
+            "@iota/pad": "^1.0.0-beta.11",
+            "@iota/signing": "^1.0.0-beta.11"
+          }
+        },
+        "@iota/bundle-validator": {
+          "version": "1.0.0-beta.11",
+          "resolved": "https://registry.npmjs.org/@iota/bundle-validator/-/bundle-validator-1.0.0-beta.11.tgz",
+          "integrity": "sha512-7OijzSNit92k0UwedQgbdAwUe7lyI2FxwMb82EGLEkrC4eQ09RJbu3f0JXLzKubUmzjwUlYGbzrGGC1AHW8cmA==",
+          "requires": {
+            "@iota/converter": "^1.0.0-beta.11",
+            "@iota/kerl": "^1.0.0-beta.11",
+            "@iota/signing": "^1.0.0-beta.11",
+            "@iota/transaction": "^1.0.0-beta.11",
+            "@iota/transaction-converter": "^1.0.0-beta.11"
+          }
+        },
+        "@iota/checksum": {
+          "version": "1.0.0-beta.11",
+          "resolved": "https://registry.npmjs.org/@iota/checksum/-/checksum-1.0.0-beta.11.tgz",
+          "integrity": "sha512-u2WR1kBAAJMoY68CGxnURr36nBz/DSKqqWgNfT9LdG3LI/Ai2CbAPUBdfZ0qKo3Z3HK9psyCyHgk6NDGyz8n6g==",
+          "requires": {
+            "@iota/converter": "^1.0.0-beta.11",
+            "@iota/kerl": "^1.0.0-beta.11"
+          }
+        },
+        "@iota/converter": {
+          "version": "1.0.0-beta.11",
+          "resolved": "https://registry.npmjs.org/@iota/converter/-/converter-1.0.0-beta.11.tgz",
+          "integrity": "sha512-euKqd0z3So/c0dz0obOcfXhJfB1riZd2nal5oM/R7uW63e4MZUP0A0libbPzGe4iHGX9XqkfAV6j2bhMdzkCFQ=="
+        },
+        "@iota/core": {
+          "version": "1.0.0-beta.11",
+          "resolved": "https://registry.npmjs.org/@iota/core/-/core-1.0.0-beta.11.tgz",
+          "integrity": "sha512-9HARB/wLPmimc9p0Nd2DWOZwFOIML3AB+7dwoS58beZ2XC0ERvfYid5vPTOahWaUfBdDZOGaDYmcISnhfBJXoA==",
+          "requires": {
+            "@iota/bundle": "^1.0.0-beta.11",
+            "@iota/bundle-validator": "^1.0.0-beta.11",
+            "@iota/checksum": "^1.0.0-beta.11",
+            "@iota/converter": "^1.0.0-beta.11",
+            "@iota/curl": "^1.0.0-beta.11",
+            "@iota/http-client": "^1.0.0-beta.11",
+            "@iota/kerl": "^1.0.0-beta.11",
+            "@iota/pad": "^1.0.0-beta.11",
+            "@iota/signing": "^1.0.0-beta.11",
+            "@iota/transaction": "^1.0.0-beta.11",
+            "@iota/transaction-converter": "^1.0.0-beta.11",
+            "@types/bluebird": "^3.5.25",
+            "bluebird": "^3.5.1"
+          }
+        },
+        "@iota/curl": {
+          "version": "1.0.0-beta.11",
+          "resolved": "https://registry.npmjs.org/@iota/curl/-/curl-1.0.0-beta.11.tgz",
+          "integrity": "sha512-b2+/S8YBGsr3beX9tg5etKItlbN7rpDIDjDnBRPsqvD9BmFyvcJe/2HxAyPeob/rPuZYoPgFw4OrdDw7ym/sZQ=="
+        },
+        "@iota/http-client": {
+          "version": "1.0.0-beta.11",
+          "resolved": "https://registry.npmjs.org/@iota/http-client/-/http-client-1.0.0-beta.11.tgz",
+          "integrity": "sha512-GsNCqUoHXmxWymnVDejderHvcACtKOOLPJjq8IMAxMBw/MCaxjlIgnMqMKvpeY/7f8gQQBEbBgnyekoHVYsM9g==",
+          "requires": {
+            "@types/bluebird": "^3.5.25",
+            "bluebird": "^3.5.1",
+            "cross-fetch": "^3.0.0"
+          }
+        },
+        "@iota/kerl": {
+          "version": "1.0.0-beta.11",
+          "resolved": "https://registry.npmjs.org/@iota/kerl/-/kerl-1.0.0-beta.11.tgz",
+          "integrity": "sha512-Yut/cl5xiBUA4wtVctgJDWtRltahSfLN8sWmRLQF7uqL/qngCRZ7iVtUehyPuXR4UlVzqU1kV/uMeuHKth2bWw==",
+          "requires": {
+            "@types/crypto-js": "^3.1.38",
+            "crypto-js": "^3.1.9-1"
+          }
+        },
+        "@iota/pad": {
+          "version": "1.0.0-beta.11",
+          "resolved": "https://registry.npmjs.org/@iota/pad/-/pad-1.0.0-beta.11.tgz",
+          "integrity": "sha512-1e6ujEhKbtk4jB+Y0Hlbg48DvdDjvbU8RUST3IrOK1NekFKVoU9KQBxm3o3RVyxos+2KPIzHddyOYbSyOIyFrw=="
+        },
+        "@iota/signing": {
+          "version": "1.0.0-beta.11",
+          "resolved": "https://registry.npmjs.org/@iota/signing/-/signing-1.0.0-beta.11.tgz",
+          "integrity": "sha512-pzYNQboly9TcgYoVO5xk8xBaQV084CrTKG+tFwlvnFUZEua9J73GBSQmmlg63R1AyC7oOPmV0yuxyT3CWdKUzw==",
+          "requires": {
+            "@iota/converter": "^1.0.0-beta.11",
+            "@iota/kerl": "^1.0.0-beta.11",
+            "@iota/pad": "^1.0.0-beta.11"
+          }
+        },
+        "@iota/transaction": {
+          "version": "1.0.0-beta.11",
+          "resolved": "https://registry.npmjs.org/@iota/transaction/-/transaction-1.0.0-beta.11.tgz",
+          "integrity": "sha512-fXQSjb169vF61d7tvzKQbbCl+rWVHoxy9kTg+OSwLnEDCh/36iEgVh1u+PyudzzyBzP5r3dbwJRZa95N8HGscw==",
+          "requires": {
+            "@iota/converter": "^1.0.0-beta.11",
+            "@iota/curl": "^1.0.0-beta.11"
+          }
+        },
+        "@iota/transaction-converter": {
+          "version": "1.0.0-beta.11",
+          "resolved": "https://registry.npmjs.org/@iota/transaction-converter/-/transaction-converter-1.0.0-beta.11.tgz",
+          "integrity": "sha512-ba/G9U8Z+er3C9SYPejxYqS/tHf7pxaCn+F0lJm5K9wd1dcHAb1F2tGsub+88J4lwZrHsrhhhMQSqf1nooNE5A==",
+          "requires": {
+            "@iota/converter": "^1.0.0-beta.11",
+            "@iota/pad": "^1.0.0-beta.11",
+            "@iota/transaction": "^1.0.0-beta.11"
+          }
+        },
+        "@types/bluebird": {
+          "version": "3.5.26",
+          "resolved": "https://registry.npmjs.org/@types/bluebird/-/bluebird-3.5.26.tgz",
+          "integrity": "sha512-aj2mrBLn5ky0GmAg6IPXrQjnN0iB/ulozuJ+oZdrHRAzRbXjGmu4UXsNCjFvPbSaaPZmniocdOzsM392qLOlmQ=="
+        },
+        "cross-fetch": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.0.1.tgz",
+          "integrity": "sha512-qWtpgBAF8ioqBOddRD+pHhrdzm/UWOArkrlIU7c08DlNbOxo5GfUbSY2vr90ZypWf0raW+HNN1F38pi5CEOjiQ==",
+          "requires": {
+            "node-fetch": "2.3.0",
+            "whatwg-fetch": "3.0.0"
+          }
+        },
         "debug": {
           "version": "3.2.6",
           "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
           "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
           "requires": {
             "ms": "^2.1.1"
+          }
+        },
+        "mam.client.js": {
+          "version": "git+ssh://git@github.com/iotaledger/mam.client.js.git#3e23dc91d56d63d1c20ad0f1396fd0cac4e3b9aa",
+          "from": "git+ssh://git@github.com/iotaledger/mam.client.js.git",
+          "requires": {
+            "@iota/converter": "^1.0.0-beta.11",
+            "@iota/core": "^1.0.0-beta.11",
+            "@iota/curl": "^1.0.0-beta.11",
+            "babel-polyfill": "^6.26.0"
           }
         },
         "minimist": {
@@ -1074,6 +568,11 @@
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
           "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
         },
+        "node-fetch": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.3.0.tgz",
+          "integrity": "sha512-MOd8pV3fxENbryESLgVIeaGKrdl+uaYhCSSVkjeOb/31/njTpcis5aWfdqgNlHIrKOLRbMnfPINPOML2CIFeXA=="
+        },
         "supports-color": {
           "version": "5.5.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
@@ -1081,228 +580,28 @@
           "requires": {
             "has-flag": "^3.0.0"
           }
-        }
-      }
-    },
-    "md5.js": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",
-      "integrity": "sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg==",
-      "requires": {
-        "hash-base": "^3.0.0",
-        "inherits": "^2.0.1",
-        "safe-buffer": "^5.1.2"
-      }
-    },
-    "miller-rabin": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-4.0.1.tgz",
-      "integrity": "sha512-115fLhvZVqWwHPbClyntxEVfVDfl9DLLTuJvq3g2O/Oxi8AiNouAHvDSzHS0viUJc+V5vm3eq91Xwqn9dp4jRA==",
-      "requires": {
-        "bn.js": "^4.0.0",
-        "brorand": "^1.0.1"
-      }
-    },
-    "minimalistic-assert": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
-      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A=="
-    },
-    "minimalistic-crypto-utils": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
-      "integrity": "sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo="
-    },
-    "minimatch": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-      "requires": {
-        "brace-expansion": "^1.1.7"
-      }
-    },
-    "minimist": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
-    },
-    "mkdirp": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-      "requires": {
-        "minimist": "0.0.8"
-      }
-    },
-    "module-deps": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/module-deps/-/module-deps-6.1.0.tgz",
-      "integrity": "sha512-NPs5N511VD1rrVJihSso/LiBShRbJALYBKzDW91uZYy7BpjnO4bGnZL3HjZ9yKcFdZUWwaYjDz9zxbuP7vKMuQ==",
-      "requires": {
-        "JSONStream": "^1.0.3",
-        "browser-resolve": "^1.7.0",
-        "cached-path-relative": "^1.0.0",
-        "concat-stream": "~1.6.0",
-        "defined": "^1.0.0",
-        "detective": "^5.0.2",
-        "duplexer2": "^0.1.2",
-        "inherits": "^2.0.1",
-        "parents": "^1.0.0",
-        "readable-stream": "^2.0.2",
-        "resolve": "^1.4.0",
-        "stream-combiner2": "^1.1.1",
-        "subarg": "^1.0.0",
-        "through2": "^2.0.0",
-        "xtend": "^4.0.0"
-      },
-      "dependencies": {
-        "resolve": {
-          "version": "1.8.1",
-          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.8.1.tgz",
-          "integrity": "sha512-AicPrAC7Qu1JxPCZ9ZgCZlY35QgFnNqc+0LtbRNxnVw4TXvjQ72wnuL9JQcEBgXkI9JM8MsT9kaQoHcpCRJOYA==",
-          "requires": {
-            "path-parse": "^1.0.5"
-          }
+        },
+        "whatwg-fetch": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.0.0.tgz",
+          "integrity": "sha512-9GSJUgz1D4MfyKU7KRqwOjXCXTqWdFNvEr7eUBYchQiVc744mqK/MzXPNR2WsPkmkOa4ywfg8C2n8h+13Bey1Q=="
         }
       }
     },
     "node-fetch": {
-      "version": "2.1.2",
-      "resolved": "http://registry.npmjs.org/node-fetch/-/node-fetch-2.1.2.tgz",
-      "integrity": "sha1-q4hOjn5X44qUR1POxwb3iNF2i7U="
-    },
-    "once": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-      "requires": {
-        "wrappy": "1"
-      }
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.3.0.tgz",
+      "integrity": "sha512-MOd8pV3fxENbryESLgVIeaGKrdl+uaYhCSSVkjeOb/31/njTpcis5aWfdqgNlHIrKOLRbMnfPINPOML2CIFeXA=="
     },
     "one-time": {
       "version": "0.0.4",
       "resolved": "https://registry.npmjs.org/one-time/-/one-time-0.0.4.tgz",
       "integrity": "sha1-+M33eISCb+Tf+T46nMN7HkSAdC4="
     },
-    "os-browserify": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.3.0.tgz",
-      "integrity": "sha1-hUNzx/XCMVkU/Jv8a9gjj92h7Cc="
-    },
-    "pako": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.6.tgz",
-      "integrity": "sha512-lQe48YPsMJAig+yngZ87Lus+NF+3mtu7DVOBu6b/gHO1YpKwIj5AWjZ/TOS7i46HD/UixzWb1zeWDZfGZ3iYcg=="
-    },
-    "parents": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/parents/-/parents-1.0.1.tgz",
-      "integrity": "sha1-/t1NK/GTp3dF/nHjcdc8MwfZx1E=",
-      "requires": {
-        "path-platform": "~0.11.15"
-      }
-    },
-    "parse-asn1": {
-      "version": "5.1.1",
-      "resolved": "http://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.1.tgz",
-      "integrity": "sha512-KPx7flKXg775zZpnp9SxJlz00gTd4BmJ2yJufSc44gMCRrRQ7NSzAcSJQfifuOLgW6bEi+ftrALtsgALeB2Adw==",
-      "requires": {
-        "asn1.js": "^4.0.0",
-        "browserify-aes": "^1.0.0",
-        "create-hash": "^1.1.0",
-        "evp_bytestokey": "^1.0.0",
-        "pbkdf2": "^3.0.3"
-      }
-    },
-    "path-browserify": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.1.tgz",
-      "integrity": "sha512-BapA40NHICOS+USX9SN4tyhq+A2RrN/Ws5F0Z5aMHDp98Fl86lX8Oti8B7uN93L4Ifv4fHOEA+pQw87gmMO/lQ=="
-    },
-    "path-is-absolute": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
-    },
-    "path-parse": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
-      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw=="
-    },
-    "path-platform": {
-      "version": "0.11.15",
-      "resolved": "https://registry.npmjs.org/path-platform/-/path-platform-0.11.15.tgz",
-      "integrity": "sha1-6GQhf3TDaFDwhSt43Hv31KVyG/I="
-    },
-    "pbkdf2": {
-      "version": "3.0.17",
-      "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.17.tgz",
-      "integrity": "sha512-U/il5MsrZp7mGg3mSQfn742na2T+1/vHDCG5/iTI3X9MKUuYUZVLQhyRsg06mCgDBTd57TxzgZt7P+fYfjRLtA==",
-      "requires": {
-        "create-hash": "^1.1.2",
-        "create-hmac": "^1.1.4",
-        "ripemd160": "^2.0.1",
-        "safe-buffer": "^5.0.1",
-        "sha.js": "^2.4.8"
-      }
-    },
-    "process": {
-      "version": "0.11.10",
-      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
-      "integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI="
-    },
     "process-nextick-args": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
       "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
-    },
-    "public-encrypt": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-4.0.3.tgz",
-      "integrity": "sha512-zVpa8oKZSz5bTMTFClc1fQOnyyEzpl5ozpi1B5YcvBrdohMjH2rfsBtyXcuNuwjsDIXmBYlF2N5FlJYhR29t8Q==",
-      "requires": {
-        "bn.js": "^4.1.0",
-        "browserify-rsa": "^4.0.0",
-        "create-hash": "^1.1.0",
-        "parse-asn1": "^5.0.0",
-        "randombytes": "^2.0.1",
-        "safe-buffer": "^5.1.2"
-      }
-    },
-    "querystring": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
-      "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA="
-    },
-    "querystring-es3": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz",
-      "integrity": "sha1-nsYfeQSYdXB9aUFFlv2Qek1xHnM="
-    },
-    "randombytes": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.0.6.tgz",
-      "integrity": "sha512-CIQ5OFxf4Jou6uOKe9t1AOgqpeU5fd70A8NPdHSGeYXqXsPe6peOwI0cUl88RWZ6sP1vPMV3avd/R6cZ5/sP1A==",
-      "requires": {
-        "safe-buffer": "^5.1.0"
-      }
-    },
-    "randomfill": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/randomfill/-/randomfill-1.0.4.tgz",
-      "integrity": "sha512-87lcbR8+MhcWcUiQ+9e+Rwx8MyR2P7qnt15ynUlbm3TU/fjbgz4GsvfSUDTemtCCtVCqb4ZcEFlyPNTh9bBTLw==",
-      "requires": {
-        "randombytes": "^2.0.5",
-        "safe-buffer": "^5.1.0"
-      }
-    },
-    "read-only-stream": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/read-only-stream/-/read-only-stream-2.0.0.tgz",
-      "integrity": "sha1-JyT9aoET1zdkrCiNQ4YnDB2/F/A=",
-      "requires": {
-        "readable-stream": "^2.0.2"
-      }
     },
     "readable-stream": {
       "version": "2.3.6",
@@ -1323,58 +622,10 @@
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
       "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
     },
-    "resolve": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
-      "integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs="
-    },
-    "ripemd160": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.2.tgz",
-      "integrity": "sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==",
-      "requires": {
-        "hash-base": "^3.0.0",
-        "inherits": "^2.0.1"
-      }
-    },
     "safe-buffer": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
-    },
-    "sha.js": {
-      "version": "2.4.11",
-      "resolved": "http://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
-      "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
-      "requires": {
-        "inherits": "^2.0.1",
-        "safe-buffer": "^5.0.1"
-      }
-    },
-    "shasum": {
-      "version": "1.0.2",
-      "resolved": "http://registry.npmjs.org/shasum/-/shasum-1.0.2.tgz",
-      "integrity": "sha1-5wEjENj0F/TetXEhUOVni4euVl8=",
-      "requires": {
-        "json-stable-stringify": "~0.0.0",
-        "sha.js": "~2.4.4"
-      }
-    },
-    "shell-quote": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.6.1.tgz",
-      "integrity": "sha1-9HgZSczkAmlxJ0MOo7PFR29IF2c=",
-      "requires": {
-        "array-filter": "~0.0.0",
-        "array-map": "~0.0.0",
-        "array-reduce": "~0.0.0",
-        "jsonify": "~0.0.0"
-      }
-    },
-    "simple-concat": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.0.tgz",
-      "integrity": "sha1-c0TLuLbib7J9ZrL8hvn21Zl1IcY="
     },
     "simple-swizzle": {
       "version": "0.2.2",
@@ -1391,54 +642,10 @@
         }
       }
     },
-    "source-map": {
-      "version": "0.5.7",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-      "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
-    },
     "stack-trace": {
       "version": "0.0.10",
       "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
       "integrity": "sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA="
-    },
-    "stream-browserify": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-2.0.1.tgz",
-      "integrity": "sha1-ZiZu5fm9uZQKTkUUyvtDu3Hlyds=",
-      "requires": {
-        "inherits": "~2.0.1",
-        "readable-stream": "^2.0.2"
-      }
-    },
-    "stream-combiner2": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/stream-combiner2/-/stream-combiner2-1.1.1.tgz",
-      "integrity": "sha1-+02KFCDqNidk4hrUeAOXvry0HL4=",
-      "requires": {
-        "duplexer2": "~0.1.0",
-        "readable-stream": "^2.0.2"
-      }
-    },
-    "stream-http": {
-      "version": "2.8.3",
-      "resolved": "https://registry.npmjs.org/stream-http/-/stream-http-2.8.3.tgz",
-      "integrity": "sha512-+TSkfINHDo4J+ZobQLWiMouQYB+UVYFttRA94FpEzzJ7ZdqcL4uUUQ7WkdkI4DSozGmgBUE/a47L+38PenXhUw==",
-      "requires": {
-        "builtin-status-codes": "^3.0.0",
-        "inherits": "^2.0.1",
-        "readable-stream": "^2.3.6",
-        "to-arraybuffer": "^1.0.0",
-        "xtend": "^4.0.0"
-      }
-    },
-    "stream-splicer": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/stream-splicer/-/stream-splicer-2.0.0.tgz",
-      "integrity": "sha1-G2O+Q4oTPktnHMGTUZdgAXWRDYM=",
-      "requires": {
-        "inherits": "^2.0.1",
-        "readable-stream": "^2.0.2"
-      }
     },
     "string_decoder": {
       "version": "1.1.1",
@@ -1448,47 +655,10 @@
         "safe-buffer": "~5.1.0"
       }
     },
-    "subarg": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/subarg/-/subarg-1.0.0.tgz",
-      "integrity": "sha1-9izxdYHplrSPyWVpn1TAauJouNI=",
-      "requires": {
-        "minimist": "^1.1.0"
-      },
-      "dependencies": {
-        "minimist": {
-          "version": "1.2.0",
-          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
-        }
-      }
-    },
-    "syntax-error": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/syntax-error/-/syntax-error-1.4.0.tgz",
-      "integrity": "sha512-YPPlu67mdnHGTup2A8ff7BC2Pjq0e0Yp/IyTFN03zWO0RcK07uLcbi7C2KpGR2FvWbaB0+bfE27a+sBKebSo7w==",
-      "requires": {
-        "acorn-node": "^1.2.0"
-      }
-    },
     "text-hex": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/text-hex/-/text-hex-1.0.0.tgz",
       "integrity": "sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg=="
-    },
-    "through": {
-      "version": "2.3.8",
-      "resolved": "http://registry.npmjs.org/through/-/through-2.3.8.tgz",
-      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
-    },
-    "through2": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
-      "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
-      "requires": {
-        "readable-stream": "~2.3.6",
-        "xtend": "~4.0.1"
-      }
     },
     "tic.api.js": {
       "version": "git+https://github.com/cr0ssing/tic.api.js.git#fc0435df53689ea8ea2b4cf0c310ec87d1505982",
@@ -1498,88 +668,20 @@
         "mam.tools.js": "^0.5.1"
       }
     },
-    "timers-browserify": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-1.4.2.tgz",
-      "integrity": "sha1-ycWLV1voQHN1y14kYtrO50NZ9B0=",
-      "requires": {
-        "process": "~0.11.0"
-      }
-    },
-    "to-arraybuffer": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/to-arraybuffer/-/to-arraybuffer-1.0.1.tgz",
-      "integrity": "sha1-fSKbH8xjfkZsoIEYCDanqr/4P0M="
-    },
     "triple-beam": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/triple-beam/-/triple-beam-1.3.0.tgz",
       "integrity": "sha512-XrHUvV5HpdLmIj4uVMxHggLbFSZYIn7HEWsqePZcI50pco+MPqJ50wMGY794X7AOOhxOBAjbkqfAbEe/QMp2Lw=="
-    },
-    "tty-browserify": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.1.tgz",
-      "integrity": "sha512-C3TaO7K81YvjCgQH9Q1S3R3P3BtN3RIM8n+OvX4il1K1zgE8ZhI0op7kClgkxtutIE8hQrcrHBXvIheqKUUCxw=="
-    },
-    "typedarray": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
-      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
-    },
-    "umd": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/umd/-/umd-3.0.3.tgz",
-      "integrity": "sha512-4IcGSufhFshvLNcMCV80UnQVlZ5pMOC8mvNPForqwA4+lzYQuetTESLDQkeLmihq8bRcnpbQa48Wb8Lh16/xow=="
-    },
-    "undeclared-identifiers": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/undeclared-identifiers/-/undeclared-identifiers-1.1.2.tgz",
-      "integrity": "sha512-13EaeocO4edF/3JKime9rD7oB6QI8llAGhgn5fKOPyfkJbRb6NFv9pYV6dFEmpa4uRjKeBqLZP8GpuzqHlKDMQ==",
-      "requires": {
-        "acorn-node": "^1.3.0",
-        "get-assigned-identifiers": "^1.2.0",
-        "simple-concat": "^1.0.0",
-        "xtend": "^4.0.1"
-      }
-    },
-    "url": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/url/-/url-0.11.0.tgz",
-      "integrity": "sha1-ODjpfPxgUh63PFJajlW/3Z4uKPE=",
-      "requires": {
-        "punycode": "1.3.2",
-        "querystring": "0.2.0"
-      },
-      "dependencies": {
-        "punycode": {
-          "version": "1.3.2",
-          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
-          "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0="
-        }
-      }
-    },
-    "util": {
-      "version": "0.10.4",
-      "resolved": "https://registry.npmjs.org/util/-/util-0.10.4.tgz",
-      "integrity": "sha512-0Pm9hTQ3se5ll1XihRic3FDIku70C+iHUdT/W926rSgHV5QgXsYbKZN8MSC3tJtSkhuROzvsQjAaFENRXr+19A==",
-      "requires": {
-        "inherits": "2.0.3"
-      }
     },
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
-    "vm-browserify": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-1.1.0.tgz",
-      "integrity": "sha512-iq+S7vZJE60yejDYM0ek6zg308+UZsdtPExWP9VZoCFCz1zkJoXFnAX7aZfd/ZwrkidzdUZL0C/ryW+JwAiIGw=="
-    },
     "whatwg-fetch": {
-      "version": "2.0.4",
-      "resolved": "http://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.4.tgz",
-      "integrity": "sha512-dcQ1GWpOD/eEQ97k66aiEVpNnapVj90/+R+SXTPYGHpYBBypfKJEQjLrvMZ7YXbKm21gXd4NcuxUTjiv1YtLng=="
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.0.0.tgz",
+      "integrity": "sha512-9GSJUgz1D4MfyKU7KRqwOjXCXTqWdFNvEr7eUBYchQiVc744mqK/MzXPNR2WsPkmkOa4ywfg8C2n8h+13Bey1Q=="
     },
     "winston": {
       "version": "3.1.0",
@@ -1606,20 +708,10 @@
         "triple-beam": "^1.2.0"
       }
     },
-    "wrappy": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
-    },
     "xmlhttprequest": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/xmlhttprequest/-/xmlhttprequest-1.8.0.tgz",
       "integrity": "sha1-Z/4HXFwk/vOfnWX197f+dRcZaPw="
-    },
-    "xtend": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
     }
   }
 }

--- a/packages/did/package.json
+++ b/packages/did/package.json
@@ -20,6 +20,7 @@
     "did-resolver": "0.0.4",
     "js-sha3": "^0.8.0",
     "mam.tools.js": "^0.5.1",
+    "mam.client.js": "git+https://git@github.com/iotaledger/mam.client.js.git",
     "tic.api.js": "git+https://github.com/cr0ssing/tic.api.js.git"
   },
   "publishConfig": {

--- a/packages/did/test/did.test.js
+++ b/packages/did/test/did.test.js
@@ -2,9 +2,13 @@ const mock = require('mam.tools.js/test/mamMock');
 
 const { DIDUtils } = require('../src/index');
 
-jest.mock('mam.client.js', () => {
-  return mock;
-});
+jest.mock(
+  'mam.client.js',
+  () => {
+    return mock;
+  },
+  { virtual: true }
+);
 
 describe('Register and Resolve DID Document', () => {
   it('Create DID document', async () => {


### PR DESCRIPTION
In order to test the MAM without interaction with the real iota node,
we use the mam.tools.js to mock the MAM client, but mocking mam client
was failed.

To fix this problem, set the virtual option and add the mam.client.js
into package dependencies.