### PR TITLE
Fix module usage not correspond to documentation

### DIFF
--- a/packages/did/src/index.js
+++ b/packages/did/src/index.js
@@ -1,6 +1,4 @@
 const register = require('./register');
 const resolver = require('./resolver');
 
-const DIDUtils = { register, resolver };
-
-export { DIDUtils };
+export { register, resolver };

--- a/packages/did/test/did.test.js
+++ b/packages/did/test/did.test.js
@@ -1,6 +1,6 @@
 const mock = require('mam.tools.js/test/mamMock');
 
-const { DIDUtils } = require('../src/index');
+const { register, resolver } = require('../src/index');
 
 jest.mock(
   'mam.client.js',
@@ -14,8 +14,8 @@ describe('Register and Resolve DID Document', () => {
   it('Create DID document', async () => {
     const seed = 'THISISTHESEEDOFTHETICACCOUNTANDISHOULDNOTGIVEITTOANYBODYELSE';
 
-    const result = await DIDUtils.register(seed, '0x2');
-    let didDoc = await DIDUtils.resolver(result.did);
+    const result = await register(seed, '0x2');
+    let didDoc = await resolver(result.did);
     expect(didDoc).toEqual({
       '@context': 'https://w3id.org/did/v1',
       id: result.did


### PR DESCRIPTION
To make the API documentation reflect the module usage, remove
the unnecessary variable "DIDUtils".