### PR TITLE
Add  network identifier description

### DIFF
--- a/packages/did/README.md
+++ b/packages/did/README.md
@@ -37,6 +37,15 @@ const did =
 let didDoc = await resolver(result.did);
 ```
 
+## Network Identifiers
+
+Used to describe which Tangle network interacts.
+
+| Identitier | Network        |
+| ---------- | -------------- |
+| 0x1        | Tangle Mainnet |
+| 0x2        | Tangle Devnet  |
+
 ## API Reference
 
 
@@ -54,7 +63,7 @@ let didDoc = await resolver(result.did);
 | Param | Type | Description |
 | --- | --- | --- |
 | seed | <code>String</code> | The seed for the master channel. |
-| network | <code>String</code> | The network identitfer. Mainnet: '0x1', Testnet: '0x2'. |
+| network | <code>String</code> | The network identitfer. |
 | registry | [<code>IdenityRegistry</code>](#IdenityRegistry) | The registry used to maintain the identity. |
 
 Register the TangleID DID(Decentralized Identifier) on the IOTA/Tangle.

--- a/packages/did/README.template
+++ b/packages/did/README.template
@@ -37,6 +37,15 @@ const did =
 let didDoc = await resolver(result.did);
 ```
 
+## Network Identifiers
+
+Used to describe which Tangle network interacts.
+
+| Identitier | Network        |
+| ---------- | -------------- |
+| 0x1        | Tangle Mainnet |
+| 0x2        | Tangle Devnet  |
+
 ## API Reference
 
 {{#module name="did"~}}

--- a/packages/did/src/IdenityRegistry.js
+++ b/packages/did/src/IdenityRegistry.js
@@ -44,7 +44,7 @@ class IdenityRegistry {
 
   /**
    * Publish the DID document to the Tangle MAM channel with specific network.
-   * @param {string} network - The network identitfer. Mainnet: '0x1', Testnet: '0x2'.
+   * @param {string} network - The network identitfer.
    * @param {string} seed - The seed of the MAM channel.
    * @returns {Promise} Promise object represents the result. The result conatains DID `did` and DID document `document`.
    */

--- a/packages/did/src/register.js
+++ b/packages/did/src/register.js
@@ -5,7 +5,7 @@ const IdenityRegistry = require('./IdenityRegistry');
  * Register the TangleID DID(Decentralized Identifier) on the IOTA/Tangle.
  * @method register
  * @param {String} seed - The seed for the master channel.
- * @param {String} network - The network identitfer. Mainnet: '0x1', Testnet: '0x2'.
+ * @param {String} network - The network identitfer.
  * @param {IdenityRegistry} registry - The registry used to maintain the identity.
  * @return {Promise} Promise object represents the register result.
  */


### PR DESCRIPTION
To eliminate duplicate network identifier description, move the
network identifier description to the README.