### PR TITLE
Migrate to tangle mainnet

### DIFF
--- a/packages/did/README.md
+++ b/packages/did/README.md
@@ -18,13 +18,13 @@ yarn add @tangleid/did
 
 ## Quick Start
 
-### Register DID
+### Register Identity to Mainnet
 
 ```javascript
 const { register } = require('@tangleid/did');
 
 const seed = 'THISISTHESEEDOFTHETICACCOUNTANDISHOULDNOTGIVEITTOANYBODYELSE';
-const result = await register(seed, '0x2');
+const result = await register(seed, '0x1');
 ```
 
 ### Resolve DID Document

--- a/packages/did/README.template
+++ b/packages/did/README.template
@@ -18,13 +18,13 @@ yarn add @tangleid/did
 
 ## Quick Start
 
-### Register DID
+### Register Identity to Mainnet
 
 ```javascript
 const { register } = require('@tangleid/did');
 
 const seed = 'THISISTHESEEDOFTHETICACCOUNTANDISHOULDNOTGIVEITTOANYBODYELSE';
-const result = await register(seed, '0x2');
+const result = await register(seed, '0x1');
 ```
 
 ### Resolve DID Document

--- a/packages/did/test/did.test.js
+++ b/packages/did/test/did.test.js
@@ -13,7 +13,7 @@ jest.mock(
 describe('Idenity registration', () => {
   it('resolved document MUST be same as published document', async () => {
     const seed = 'THISISTHESEEDOFTHETICACCOUNTANDISHOULDNOTGIVEITTOANYBODYELSE';
-    const { did, document } = await register(seed, '0x2');
+    const { did, document } = await register(seed, '0x1');
     const resolved = await resolver(did);
 
     expect(resolved).toEqual(document);


### PR DESCRIPTION
Since the nodes of devnet are less, it is preferred to use the mainnet
instead.
Modify the sample code and test case to register identity to the
mainnet.