### PR TITLE
Refactor register function

### DIFF
--- a/packages/did/README.md
+++ b/packages/did/README.md
@@ -24,7 +24,7 @@ yarn add @tangleid/did
 const { register } = require('@tangleid/did');
 
 const seed = 'THISISTHESEEDOFTHETICACCOUNTANDISHOULDNOTGIVEITTOANYBODYELSE';
-const result = await register(seed, '0x1');
+const { did, document, seed } = await register({ seed, network: '0x1' });
 ```
 
 ### Resolve DID Document
@@ -51,20 +51,21 @@ Used to describe which Tangle network interacts.
 
 * [did](#module_did)
 
-    * [~register(seed, network, registry)](#module_did..register)
+    * [~register([options])](#module_did..register)
 
     * [~resolver(did, registry)](#module_did..resolver)
 
 
 <a name="module_did..register"></a>
 
-### *did*~register(seed, network, registry)
+### *did*~register([options])
 
-| Param | Type | Description |
-| --- | --- | --- |
-| seed | <code>String</code> | The seed for the master channel. |
-| network | <code>String</code> | The network identitfer. |
-| registry | [<code>IdenityRegistry</code>](#IdenityRegistry) | The registry used to maintain the identity. |
+| Param | Type | Default | Description |
+| --- | --- | --- | --- |
+| [options] | <code>Object</code> |  | Registration options |
+| [options.seed] | <code>string</code> | <code>&quot;mamClient.generateSeed()&quot;</code> | The seed for the master channel. |
+| [options.network] | <code>string</code> | <code>&quot;0x1&quot;</code> | The network identitfer. |
+| [options.registry] | [<code>IdenityRegistry</code>](#IdenityRegistry) | <code>new IdenityRegistry()</code> | The registry used to maintain the identity. |
 
 Register the TangleID DID(Decentralized Identifier) on the IOTA/Tangle.
 

--- a/packages/did/README.template
+++ b/packages/did/README.template
@@ -24,7 +24,7 @@ yarn add @tangleid/did
 const { register } = require('@tangleid/did');
 
 const seed = 'THISISTHESEEDOFTHETICACCOUNTANDISHOULDNOTGIVEITTOANYBODYELSE';
-const result = await register(seed, '0x1');
+const { did, document, seed } = await register({ seed, network: '0x1' });
 ```
 
 ### Resolve DID Document

--- a/packages/did/src/register.js
+++ b/packages/did/src/register.js
@@ -1,15 +1,21 @@
 /** @module did */
+const mamClient = require('mam.tools.js');
 const IdenityRegistry = require('./IdenityRegistry');
 
 /**
  * Register the TangleID DID(Decentralized Identifier) on the IOTA/Tangle.
  * @method register
- * @param {String} seed - The seed for the master channel.
- * @param {String} network - The network identitfer.
- * @param {IdenityRegistry} registry - The registry used to maintain the identity.
+ * @param {Object} [options] Registration options
+ * @param {string} [options.seed = mamClient.generateSeed()] - The seed for the master channel.
+ * @param {string} [options.network = 0x1] - The network identitfer.
+ * @param {IdenityRegistry} [options.registry = new IdenityRegistry()] - The registry used to maintain the identity.
  * @return {Promise} Promise object represents the register result.
  */
-const register = async (seed, network, registry = new IdenityRegistry()) => {
+const register = async ({
+  seed = mamClient.generateSeed(),
+  network = '0x1',
+  registry = new IdenityRegistry()
+}) => {
   const { did, document } = await registry.publish(network, seed);
   return {
     did,

--- a/packages/did/test/did.test.js
+++ b/packages/did/test/did.test.js
@@ -13,7 +13,7 @@ jest.mock(
 describe('Idenity registration', () => {
   it('resolved document MUST be same as published document', async () => {
     const seed = 'THISISTHESEEDOFTHETICACCOUNTANDISHOULDNOTGIVEITTOANYBODYELSE';
-    const { did, document } = await register(seed, '0x1');
+    const { did, document } = await register({ seed, network: '0x1' });
     const resolved = await resolver(did);
 
     expect(resolved).toEqual(document);


### PR DESCRIPTION
To refactor the register function, the following changes are applied:
 - Pass the object parameter as register option
 - Generate the seed if not provided
 - Use the mainnet if not specified the network identifier

Because register function is changed, modify the document as well.