### PR TITLE
Register DID document with public keys

### DIFF
--- a/packages/did/README.md
+++ b/packages/did/README.md
@@ -24,7 +24,8 @@ yarn add @tangleid/did
 const { register } = require('@tangleid/did');
 
 const seed = 'THISISTHESEEDOFTHETICACCOUNTANDISHOULDNOTGIVEITTOANYBODYELSE';
-const { did, document, seed } = await register({ seed, network: '0x1' });
+const publicKey = '-----BEGIN PUBLIC KEY-----//..-----END PUBLIC KEY-----'
+const { did, document, seed } = await register({ seed, network: '0x1', publicKey });
 ```
 
 ### Resolve DID Document
@@ -65,6 +66,7 @@ Used to describe which Tangle network interacts.
 | [options] | <code>Object</code> |  | Registration options |
 | [options.seed] | <code>string</code> | <code>&quot;mamClient.generateSeed()&quot;</code> | The seed for the master channel. |
 | [options.network] | <code>string</code> | <code>&quot;0x1&quot;</code> | The network identitfer. |
+| [options.publicKey] | <code>String</code> \| <code>Array.&lt;string&gt;</code> | <code>[]</code> | PEM-formatted public Key. |
 | [options.registry] | [<code>IdenityRegistry</code>](#IdenityRegistry) | <code>new IdenityRegistry()</code> | The registry used to maintain the identity. |
 
 Register the TangleID DID(Decentralized Identifier) on the IOTA/Tangle.

--- a/packages/did/README.template
+++ b/packages/did/README.template
@@ -24,7 +24,8 @@ yarn add @tangleid/did
 const { register } = require('@tangleid/did');
 
 const seed = 'THISISTHESEEDOFTHETICACCOUNTANDISHOULDNOTGIVEITTOANYBODYELSE';
-const { did, document, seed } = await register({ seed, network: '0x1' });
+const publicKey = '-----BEGIN PUBLIC KEY-----//..-----END PUBLIC KEY-----'
+const { did, document, seed } = await register({ seed, network: '0x1', publicKey });
 ```
 
 ### Resolve DID Document

--- a/packages/did/package-lock.json
+++ b/packages/did/package-lock.json
@@ -593,6 +593,11 @@
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.3.0.tgz",
       "integrity": "sha512-MOd8pV3fxENbryESLgVIeaGKrdl+uaYhCSSVkjeOb/31/njTpcis5aWfdqgNlHIrKOLRbMnfPINPOML2CIFeXA=="
     },
+    "node-forge": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.8.2.tgz",
+      "integrity": "sha512-mXQ9GBq1N3uDCyV1pdSzgIguwgtVpM7f5/5J4ipz12PKWElmPpVWLDuWl8iXmhysr21+WmX/OJ5UKx82wjomgg=="
+    },
     "one-time": {
       "version": "0.0.4",
       "resolved": "https://registry.npmjs.org/one-time/-/one-time-0.0.4.tgz",

--- a/packages/did/package.json
+++ b/packages/did/package.json
@@ -19,8 +19,9 @@
     "buffer": "^5.2.0",
     "did-resolver": "0.0.4",
     "js-sha3": "^0.8.0",
-    "mam.tools.js": "^0.5.1",
     "mam.client.js": "git+https://git@github.com/iotaledger/mam.client.js.git",
+    "mam.tools.js": "^0.5.1",
+    "node-forge": "^0.8.2",
     "tic.api.js": "git+https://github.com/cr0ssing/tic.api.js.git"
   },
   "publishConfig": {

--- a/packages/did/src/IdenityRegistry.js
+++ b/packages/did/src/IdenityRegistry.js
@@ -2,6 +2,7 @@ const tic = require('tic.api.js');
 const mamClient = require('mam.tools.js');
 
 const { encodeToDid, decodeFromDid } = require('./mnid');
+const { generatePublicKeys } = require('./did');
 
 const DEFAULT_PROVIDERS = {
   '0x1': 'https://nodes.thetangle.org:443',
@@ -46,15 +47,20 @@ class IdenityRegistry {
    * Publish the DID document to the Tangle MAM channel with specific network.
    * @param {string} network - The network identitfer.
    * @param {string} seed - The seed of the MAM channel.
+   * @param {string[]} publicKeys - PEM-formatted public Keys.
    * @returns {Promise} Promise object represents the result. The result conatains DID `did` and DID document `document`.
    */
-  publish = async (network, seed) => {
+  publish = async (network, seed, publicKeys = []) => {
     const ticClient = await this.getTicClient(network, seed);
     const did = encodeToDid({ network, address: ticClient.masterRoot });
     const document = {
       '@context': 'https://w3id.org/did/v1',
       id: did
     };
+
+    if (publicKeys.length > 0) {
+      document.publicKey = generatePublicKeys(did, publicKeys);
+    }
 
     await tic.profile.putInfo(ticClient.profile, document);
 

--- a/packages/did/src/did.js
+++ b/packages/did/src/did.js
@@ -1,0 +1,27 @@
+/**
+ * Generate public keys from PEM-formatted public Keys.
+ * @function generatePublicKeys
+ * @param {string} controller - DID of the controller.
+ * @param {string[]} publicKeyPems - PEM-formatted public Keys.
+ * @returns {Object[]} Public keys
+ */
+const generatePublicKeys = (controller, publicKeyPems) => {
+  if (controller === undefined) {
+    throw new Error('controller is not specified');
+  }
+
+  if (publicKeyPems === undefined) {
+    throw new Error('publicKeyPems is not specified');
+  }
+
+  return publicKeyPems.map((publicKeyPem, index) => ({
+    id: `${controller}#keys-${index + 1}`,
+    type: 'RsaVerificationKey2018',
+    controller,
+    publicKeyPem
+  }));
+};
+
+module.exports = {
+  generatePublicKeys
+};

--- a/packages/did/src/register.js
+++ b/packages/did/src/register.js
@@ -8,15 +8,18 @@ const IdenityRegistry = require('./IdenityRegistry');
  * @param {Object} [options] Registration options
  * @param {string} [options.seed = mamClient.generateSeed()] - The seed for the master channel.
  * @param {string} [options.network = 0x1] - The network identitfer.
+ * @param {String|string[]} [options.publicKey = []] - PEM-formatted public Key.
  * @param {IdenityRegistry} [options.registry = new IdenityRegistry()] - The registry used to maintain the identity.
  * @return {Promise} Promise object represents the register result.
  */
 const register = async ({
   seed = mamClient.generateSeed(),
   network = '0x1',
+  publicKey = [],
   registry = new IdenityRegistry()
 }) => {
-  const { did, document } = await registry.publish(network, seed);
+  const publicKeys = Array.isArray(publicKey) ? publicKey : [publicKey];
+  const { did, document } = await registry.publish(network, seed, publicKeys);
   return {
     did,
     seed,

--- a/packages/did/test/did.test.js
+++ b/packages/did/test/did.test.js
@@ -2,6 +2,7 @@ const mock = require('mam.tools.js/test/mamMock');
 const { log } = require('mam.tools.js/lib/logger');
 
 const { register, resolver } = require('../src/index');
+const { generateKeyPair } = require('./utils');
 
 // disable mam.tools.js console logging
 log.silent = true;
@@ -14,12 +15,31 @@ jest.mock(
   { virtual: true }
 );
 
-describe('Idenity registration', () => {
-  it('resolved document MUST be same as published document', async () => {
-    const seed = 'THISISTHESEEDOFTHETICACCOUNTANDISHOULDNOTGIVEITTOANYBODYELSE';
-    const { did, document } = await register({ seed, network: '0x1' });
-    const resolved = await resolver(did);
+let publicKey, did, document, resolved;
 
+beforeAll(async () => {
+  const keypair = generateKeyPair();
+  publicKey = keypair.publicKey;
+
+  const result = await register({
+    network: '0x1',
+    publicKey
+  });
+  did = result.did;
+  document = result.document;
+  resolved = await resolver(did);
+});
+
+describe('Idenity registration', () => {
+  it('resolved document MUST be same as published document', () => {
     expect(resolved).toEqual(document);
+  });
+
+  it('public key property MUST be Array', () => {
+    expect(Array.isArray(resolved.publicKey)).toBe(true);
+  });
+
+  it('public key property length MUST be 1', () => {
+    expect(resolved.publicKey).toHaveLength(1);
   });
 });

--- a/packages/did/test/utils.js
+++ b/packages/did/test/utils.js
@@ -1,0 +1,22 @@
+const forge = require('node-forge');
+
+/**
+ * Generate RSA key pairs.
+ * @function generateKeyPair
+ * @param {object} [options] - Generate key pair options.
+ * @param {number} [bits] - Key length of key pair.
+ */
+const generateKeyPair = ({ bits = 1024 } = {}) => {
+  const keypair = forge.rsa.generateKeyPair({ bits });
+  const publicKey = forge.pki.publicKeyToPem(keypair.publicKey);
+  const privateKey = forge.pki.privateKeyToPem(keypair.privateKey);
+
+  return {
+    publicKey,
+    privateKey
+  };
+};
+
+module.exports = {
+  generateKeyPair
+};


### PR DESCRIPTION
It is crucial to describe the public keys on the DID document, these
public keys will be used to digital signatures, encryption and
cryptographic operations, so modify the register to describe the
public keys on the DID document.

See also: https://w3c-ccg.github.io/did-spec/#public-keys