### PR TITLE
Migrate deprecated buffer function

### DIFF
--- a/packages/did/src/mnid.js
+++ b/packages/did/src/mnid.js
@@ -15,7 +15,7 @@ function checksum(payload) {
 
 function encode({ network, address }) {
   const payload = [
-    new Buffer('01', 'hex'),
+    Buffer.from('01', 'hex'),
     hex.decode(network.slice(2)),
     tryte.decode(address.slice(0, 81))
   ];


### PR DESCRIPTION
Since Buffer() is deprecated due to security and usability issues,
use Buffer.from() method instead.