### PR TITLE
Disable logging when running test cases

### DIFF
--- a/packages/did/test/did.test.js
+++ b/packages/did/test/did.test.js
@@ -1,6 +1,10 @@
 const mock = require('mam.tools.js/test/mamMock');
+const { log } = require('mam.tools.js/lib/logger');
 
 const { register, resolver } = require('../src/index');
+
+// disable mam.tools.js console logging
+log.silent = true;
 
 jest.mock(
   'mam.client.js',


### PR DESCRIPTION
By default, the "mam.tools.js" log each operation to the console,
set the silent mode to disable the logging.