### PR TITLE
Allow specified nodes with register and resolver

### DIFF
--- a/packages/did/README.md
+++ b/packages/did/README.md
@@ -24,14 +24,52 @@ yarn add @tangleid/did
 const { register } = require('@tangleid/did');
 
 const seed = 'THISISTHESEEDOFTHETICACCOUNTANDISHOULDNOTGIVEITTOANYBODYELSE';
-const publicKey = '-----BEGIN PUBLIC KEY-----//..-----END PUBLIC KEY-----'
+const publicKey = '-----BEGIN PUBLIC KEY-----//..-----END PUBLIC KEY-----';
 const { did, document, seed } = await register({ seed, network: '0x1', publicKey });
+```
+
+#### Register Identity with Specific Nodes
+
+```javascript
+import { register, IdenityRegistry } from '@tangleid/did';
+const seed = 'THISISTHESEEDOFTHETICACCOUNTANDISHOULDNOTGIVEITTOANYBODYELSE';
+const publicKey = '-----BEGIN PUBLIC KEY-----//..-----END PUBLIC KEY-----';
+const registry = new IdenityRegistry({
+  providers: {
+    '0x1': 'https://nodes.thetangle.org:443',
+    '0x2': 'https://nodes.devnet.thetangle.org:443',
+  },
+});
+
+const { did, document, seed } = await register({
+  seed,
+  network: '0x1',
+  publicKey,
+  registry,
+});
 ```
 
 ### Resolve DID Document
 
 ```javascript
 const { resolver } = require('@tangleid/did');
+
+const did =
+  'did:tangleid:MoWYKbBfezWbsTkYAngUu523F8YQgHfARhWWsTFSN2U45eAMpsSx3DnrV4SyZHCFuyDqjvQdg7';
+let didDoc = await resolver(result.did);
+```
+
+#### Resolve DID Document with Specific Nodes
+
+```javascript
+const { resolver, IdenityRegistry } = require('@tangleid/did');
+
+const registry = new IdenityRegistry({
+  providers: {
+    '0x1': 'https://nodes.thetangle.org:443',
+    '0x2': 'https://nodes.devnet.thetangle.org:443',
+  },
+});
 
 const did =
   'did:tangleid:MoWYKbBfezWbsTkYAngUu523F8YQgHfARhWWsTFSN2U45eAMpsSx3DnrV4SyZHCFuyDqjvQdg7';

--- a/packages/did/README.template
+++ b/packages/did/README.template
@@ -24,14 +24,52 @@ yarn add @tangleid/did
 const { register } = require('@tangleid/did');
 
 const seed = 'THISISTHESEEDOFTHETICACCOUNTANDISHOULDNOTGIVEITTOANYBODYELSE';
-const publicKey = '-----BEGIN PUBLIC KEY-----//..-----END PUBLIC KEY-----'
+const publicKey = '-----BEGIN PUBLIC KEY-----//..-----END PUBLIC KEY-----';
 const { did, document, seed } = await register({ seed, network: '0x1', publicKey });
+```
+
+#### Register Identity with Specific Nodes
+
+```javascript
+import { register, IdenityRegistry } from '@tangleid/did';
+const seed = 'THISISTHESEEDOFTHETICACCOUNTANDISHOULDNOTGIVEITTOANYBODYELSE';
+const publicKey = '-----BEGIN PUBLIC KEY-----//..-----END PUBLIC KEY-----';
+const registry = new IdenityRegistry({
+  providers: {
+    '0x1': 'https://nodes.thetangle.org:443',
+    '0x2': 'https://nodes.devnet.thetangle.org:443',
+  },
+});
+
+const { did, document, seed } = await register({
+  seed,
+  network: '0x1',
+  publicKey,
+  registry,
+});
 ```
 
 ### Resolve DID Document
 
 ```javascript
 const { resolver } = require('@tangleid/did');
+
+const did =
+  'did:tangleid:MoWYKbBfezWbsTkYAngUu523F8YQgHfARhWWsTFSN2U45eAMpsSx3DnrV4SyZHCFuyDqjvQdg7';
+let didDoc = await resolver(result.did);
+```
+
+#### Resolve DID Document with Specific Nodes
+
+```javascript
+const { resolver, IdenityRegistry } = require('@tangleid/did');
+
+const registry = new IdenityRegistry({
+  providers: {
+    '0x1': 'https://nodes.thetangle.org:443',
+    '0x2': 'https://nodes.devnet.thetangle.org:443',
+  },
+});
 
 const did =
   'did:tangleid:MoWYKbBfezWbsTkYAngUu523F8YQgHfARhWWsTFSN2U45eAMpsSx3DnrV4SyZHCFuyDqjvQdg7';

--- a/packages/did/src/index.js
+++ b/packages/did/src/index.js
@@ -1,4 +1,5 @@
 const register = require('./register');
 const resolver = require('./resolver');
+const IdenityRegistry = require('./IdenityRegistry');
 
-export { register, resolver };
+export { register, resolver, IdenityRegistry };


### PR DESCRIPTION
To allow using specified the IRI nodes, export the "IdentityRegistry"
class and update the quick start guide.