### PR TITLE
Fix missing babel-runtime in runtime

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -825,15 +825,6 @@
         "semver": "^5.3.0"
       }
     },
-    "@babel/runtime": {
-      "version": "7.4.2",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.4.2.tgz",
-      "integrity": "sha512-7Bl2rALb7HpvXFL7TETNzKSAeBVCPHELzc0C//9FCxN8nsiueWSJBqaF+2oIJScyILStASR/Cx5WMkXGYTiJFA==",
-      "dev": true,
-      "requires": {
-        "regenerator-runtime": "^0.13.2"
-      }
-    },
     "@babel/template": {
       "version": "7.2.2",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.2.2.tgz",
@@ -8857,12 +8848,6 @@
       "requires": {
         "regenerate": "^1.4.0"
       }
-    },
-    "regenerator-runtime": {
-      "version": "0.13.2",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.2.tgz",
-      "integrity": "sha512-S/TQAZJO+D3m9xeN1WTI8dLKBBiRgXBlTJvbWjCThHWZj9EvHK70Ff50/tYj2J/fvBY6JtFVwRuazHN2E7M9BA==",
-      "dev": true
     },
     "regenerator-transform": {
       "version": "0.13.3",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
     "@babel/plugin-proposal-class-properties": "^7.4.0",
     "@babel/plugin-transform-runtime": "^7.1.0",
     "@babel/preset-env": "^7.1.0",
-    "@babel/runtime": "^7.4.2",
     "babel-core": "^7.0.0-bridge.0",
     "dmd-clear": "^0.1.2",
     "husky": "^1.3.1",

--- a/packages/did/package-lock.json
+++ b/packages/did/package-lock.json
@@ -4,6 +4,21 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@babel/runtime": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.4.3.tgz",
+      "integrity": "sha512-9lsJwJLxDh/T3Q3SZszfWOTkk3pHbkmH+3KY+zwIDmsNlxsumuhS2TH3NIpktU4kNvfzy+k3eLT7aTJSPTo0OA==",
+      "requires": {
+        "regenerator-runtime": "^0.13.2"
+      },
+      "dependencies": {
+        "regenerator-runtime": {
+          "version": "0.13.2",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.2.tgz",
+          "integrity": "sha512-S/TQAZJO+D3m9xeN1WTI8dLKBBiRgXBlTJvbWjCThHWZj9EvHK70Ff50/tYj2J/fvBY6JtFVwRuazHN2E7M9BA=="
+        }
+      }
+    },
     "@iota/bundle": {
       "version": "1.0.0-beta.11",
       "resolved": "https://registry.npmjs.org/@iota/bundle/-/bundle-1.0.0-beta.11.tgz",

--- a/packages/did/package.json
+++ b/packages/did/package.json
@@ -15,6 +15,7 @@
     "url": "https://github.com/TangleID/tangleid-core/tree/master/packages/did"
   },
   "dependencies": {
+    "@babel/runtime": "^7.4.2",
     "base-x": "^3.0.4",
     "buffer": "^5.2.0",
     "did-resolver": "0.0.4",


### PR DESCRIPTION
The "@babel/runtime" contains some helper code and it is used for
saving the compiled code size.

Since the "@babel/runtime" is a production dependency, it should be
used in the "dependency" section in "package.json".

See also: https://babeljs.io/docs/en/babel-plugin-transform-runtime