### PR TITLE
Fix get incorrect channel roots

### DIFF
--- a/packages/did/package-lock.json
+++ b/packages/did/package-lock.json
@@ -152,23 +152,6 @@
         "lodash": "^4.17.11"
       }
     },
-    "babel-polyfill": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-polyfill/-/babel-polyfill-6.26.0.tgz",
-      "integrity": "sha1-N5k3q8Z9eJWXCtxiHyhM2WbPIVM=",
-      "requires": {
-        "babel-runtime": "^6.26.0",
-        "core-js": "^2.5.0",
-        "regenerator-runtime": "^0.10.5"
-      },
-      "dependencies": {
-        "regenerator-runtime": {
-          "version": "0.10.5",
-          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
-          "integrity": "sha1-M2w+/BIgrc7dosn6tntaeVWjNlg="
-        }
-      }
-    },
     "babel-runtime": {
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
@@ -415,12 +398,11 @@
       "requires": {
         "@iota/converter": "^1.0.0-beta.11",
         "@iota/core": "^1.0.0-beta.11",
-        "@iota/curl": "^1.0.0-beta.11",
-        "babel-polyfill": "^6.26.0"
+        "@iota/curl": "^1.0.0-beta.11"
       }
     },
     "mam.tools.js": {
-      "version": "git+https://github.com/TangleID/mam.tools.js.git#3553c7ad79da450d7a7149e0cf882e36b8a7424c",
+      "version": "git+https://github.com/TangleID/mam.tools.js.git#04dedce992cb96f33649b8968e6f2ddb2eb659b4",
       "from": "git+https://github.com/TangleID/mam.tools.js.git#develop",
       "requires": {
         "debug": "^3.1.0",
@@ -524,7 +506,7 @@
       },
       "dependencies": {
         "mam.tools.js": {
-          "version": "git+https://git@github.com/TangleID/mam.tools.js.git#3553c7ad79da450d7a7149e0cf882e36b8a7424c",
+          "version": "git+https://git@github.com/TangleID/mam.tools.js.git#04dedce992cb96f33649b8968e6f2ddb2eb659b4",
           "from": "git+https://git@github.com/TangleID/mam.tools.js.git#develop",
           "requires": {
             "debug": "^3.1.0",

--- a/packages/did/src/IdenityRegistry.js
+++ b/packages/did/src/IdenityRegistry.js
@@ -74,8 +74,8 @@ class IdenityRegistry {
    */
   fetch = async did => {
     const { network, address } = decodeFromDid(did);
-    const channelRoots = await tic.getChannelRoots(address);
     const iota = await this.getIota(network);
+    const channelRoots = await tic.getChannelRoots(address, iota);
     const profile = await tic.profile.get(channelRoots.profile, iota);
 
     return profile;


### PR DESCRIPTION
Since the getChannelRoots() function doesn't have parameter to
specified the Tangle, it causes the IdentityRegistry cannot get
correct channel roots from Tangle and failed to get the DID document.

To fix this problem, add the additional parameter to specify Tangle.