### PR TITLE
Remove redundant TravisCI configuration

### DIFF
--- a/packages/did/.travis.yml
+++ b/packages/did/.travis.yml
@@ -1,3 +1,0 @@
-language: node_js
-node_js:
-  - node


### PR DESCRIPTION
Since the project already have the TravisCI configuration in the root
directory, remove the redundant configuration file in the packages
directory.