### PR TITLE
Clean generated type definition directory

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "lint": "tslint --force --format verbose ./packages/*/src/**/*.ts",
     "test": "yarn run build && lerna exec -- yarn run test",
     "docs": "yarn run build && lerna exec -- yarn run docs",
-    "clean": "lerna exec --parallel -- rimraf lib",
+    "clean": "lerna exec --parallel -- rimraf lib typings",
     "build": "yarn run clean && lerna exec -- yarn run build",
     "audit": "yarn audit && lerna exec -- yarn audit"
   },


### PR DESCRIPTION
Building the TypsScript package will generate the "lib" and "typings"
directory, the script should clean the "typings" directory as well.