### PR TITLE
Modify test script to use Jest directly

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "init": "yarn install && lerna bootstrap",
     "lint": "tslint --force --format verbose ./packages/*/src/**/*.ts",
-    "test": "lerna exec -- yarn run test",
+    "test": "jest",
     "docs": "yarn run build && lerna exec -- yarn run docs",
     "clean": "lerna exec --parallel -- rimraf lib typings",
     "build": "yarn run clean && lerna exec -- yarn run build",


### PR DESCRIPTION
Because running the test case in each package is slow, modify the test
script to use the Jest directly to speed up the testing.