### PR TITLE
Add utilities for JSON-LD signatures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - node
+  - lts/*
 install:
   - yarn run init
 script:

--- a/packages/jsonld/README.md
+++ b/packages/jsonld/README.md
@@ -29,6 +29,12 @@ yarn add @tangleid/jsonld
 
     * [~canonize(input, [options])](#module_jsonld..canonize)
 
+    * [~generateRsaKeyPair([options])](#module_jsonld..generateRsaKeyPair)
+
+    * [~signRsaSignature(document, publicKey, privateKeyPem, [options])](#module_jsonld..signRsaSignature)
+
+    * [~verifyRsaSignature(document, [options])](#module_jsonld..verifyRsaSignature)
+
 
 <a name="module_jsonld..createDocumentLoader"></a>
 
@@ -102,3 +108,43 @@ unless the 'inputFormat' option is used. The output is an RDF dataset
 unless the 'format' option is used.
 
 **Returns**: <code>Promise.&lt;string&gt;</code> - a Promise that resolves to the normalized output.  
+<a name="module_jsonld..generateRsaKeyPair"></a>
+
+### *jsonld*~generateRsaKeyPair([options])
+
+| Param | Type | Description |
+| --- | --- | --- |
+| [options] | <code>object</code> | Generate key pair options. |
+| [options.bits] | <code>number</code> | Key length. |
+
+Generate RSA key pair in PEM-formatted.
+
+**Returns**: <code>object</code> - RSA Key pair.  
+<a name="module_jsonld..signRsaSignature"></a>
+
+### *jsonld*~signRsaSignature(document, publicKey, privateKeyPem, [options])
+
+| Param | Type | Description |
+| --- | --- | --- |
+| document | <code>object</code> | JSON-LD document to be signed. |
+| publicKey | <code>PublicKeyMeta</code> | Public key metadata. |
+| privateKeyPem | <code>string</code> | PEM-formatted private key. |
+| [options] | <code>object</code> | Options for signing the document. |
+| [options.documentLoader] | <code>object</code> | Loader that retrieve external documents. |
+
+Sign JSON-LD document with RSA crypto suite.
+
+**Returns**: <code>Promise.&lt;object&gt;</code> - Promise object represents signed JSON-LD document.  
+<a name="module_jsonld..verifyRsaSignature"></a>
+
+### *jsonld*~verifyRsaSignature(document, [options])
+
+| Param | Type | Description |
+| --- | --- | --- |
+| document | <code>object</code> | JSON-LD document to be verify. |
+| [options] | <code>object</code> | Options for verifying the signature. |
+| [options.documentLoader] | <code>object</code> | Loader that retrieve external documents. |
+
+Verify JSON-LD document signature.
+
+**Returns**: <code>Promise.&lt;boolean&gt;</code> - Promise object represents verification result.  

--- a/packages/jsonld/package.json
+++ b/packages/jsonld/package.json
@@ -15,7 +15,9 @@
     "url": "https://github.com/TangleID/TangleID"
   },
   "dependencies": {
-    "jsonld": "^1.6.0"
+    "jsonld": "^1.6.0",
+    "jsonld-signatures": "^4.1.1",
+    "node-forge": "^0.8.2"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/jsonld/src/index.ts
+++ b/packages/jsonld/src/index.ts
@@ -1,3 +1,4 @@
 export * from './jsonld';
 export * from './documentLoader';
 export * from './expansionMap';
+export * from './signature';

--- a/packages/jsonld/src/signature.ts
+++ b/packages/jsonld/src/signature.ts
@@ -1,0 +1,94 @@
+/** @module jsonld */
+import * as forge from 'node-forge';
+// @ts-ignore
+import * as jsigs from 'jsonld-signatures';
+// @ts-ignore
+import { RSAKeyPair } from 'crypto-ld';
+import { createDocumentLoader, strictExpansionMap } from '../src';
+import { RsaKeyPair, PrivateKeyPem, PublicKeyMeta } from '../../types';
+
+const { RsaSignature2018 } = jsigs.suites;
+const { AssertionProofPurpose } = jsigs.purposes;
+
+/**
+ * Generate RSA key pair in PEM-formatted.
+ * @function generateRsaKeyPair
+ * @param {object} [options] - Generate key pair options.
+ * @param {number} [options.bits] - Key length.
+ * @returns {object} RSA Key pair.
+ */
+export const generateRsaKeyPair = ({ bits = 2048 } = {}): RsaKeyPair => {
+  const keypair = forge.pki.rsa.generateKeyPair({ bits });
+  const publicKeyPem = forge.pki.publicKeyToPem(keypair.publicKey);
+  const privateKeyPem = forge.pki.privateKeyToPem(keypair.privateKey);
+
+  return {
+    publicKeyPem,
+    privateKeyPem,
+  };
+};
+
+/**
+ * Sign JSON-LD document with RSA crypto suite.
+ * @function signRsaSignature
+ * @param {object} document - JSON-LD document to be signed.
+ * @param {PublicKeyMeta} publicKey - Public key metadata.
+ * @param {string} privateKeyPem - PEM-formatted private key.
+ * @param {object} [options] - Options for signing the document.
+ * @param {object} [options.documentLoader] - Loader that retrieve external documents.
+ * @returns {Promise<object>} Promise object represents signed JSON-LD document.
+ */
+export const signRsaSignature = async (
+  document: any,
+  publicKey: PublicKeyMeta,
+  privateKeyPem: PrivateKeyPem,
+  {
+    documentLoader = createDocumentLoader(),
+  }: {
+    documentLoader?: any;
+  } = {},
+) => {
+  const publicKeyMetadata = {
+    '@context': jsigs.SECURITY_CONTEXT_URL,
+    type: 'RsaVerificationKey2018',
+    ...publicKey,
+  };
+  const key = new RSAKeyPair({ ...publicKeyMetadata, privateKeyPem });
+
+  // @ts-ignore
+  const signed = await jsigs.sign(document, {
+    suite: new RsaSignature2018({ key }),
+    purpose: new AssertionProofPurpose(),
+    documentLoader,
+    strictExpansionMap,
+  });
+
+  return signed;
+};
+
+/**
+ * Verify JSON-LD document signature.
+ * @function verifyRsaSignature
+ * @param {object} document - JSON-LD document to be verify.
+ * @param {object} [options] - Options for verifying the signature.
+ * @param {object} [options.documentLoader] - Loader that retrieve external documents.
+ * @returns {Promise<boolean>} Promise object represents verification result.
+ */
+export const verifyRsaSignature = async (
+  document: any,
+  {
+    documentLoader = createDocumentLoader(),
+  }: {
+    documentLoader?: any;
+  } = {},
+): Promise<boolean> => {
+  // @ts-ignore
+  const result = await jsigs.verify(document, {
+    suite: new RsaSignature2018(),
+    purpose: new AssertionProofPurpose(),
+    expansionMap: false,
+    documentLoader,
+  });
+
+  return result.verified;
+};

--- a/packages/jsonld/tests/mock/documentLoader.ts
+++ b/packages/jsonld/tests/mock/documentLoader.ts
@@ -5,10 +5,12 @@ import CREDENTIAL_CONTEXT from './context/credential';
 import {
   SCHEMA_CONTEXT_URL,
   CREDENTIAL_CONTEXT_URL,
+  SECURITY_CONTEXT_URL,
   SECURITY_CONTEXT_V1_URL,
   SECURITY_CONTEXT_V2_URL,
 } from '../../../contexts';
-import { createDocumentLoader } from '../../src/documentLoader';
+import { createDocumentLoader } from '../../src';
+import { PublicKeyMeta } from '../../../types';
 
 export const documents = {
   [SCHEMA_CONTEXT_URL]: SCHEMA_CONTEXT,
@@ -18,3 +20,31 @@ export const documents = {
 };
 
 export const documentLoader = createDocumentLoader(documents);
+
+export const createDocumentLoaderByMetadata = (publicKey: PublicKeyMeta) => {
+  const publicKeyDocument = {
+    '@context': SECURITY_CONTEXT_URL,
+    type: 'RsaVerificationKey2018',
+    ...publicKey,
+  };
+
+  const controllerDocument = {
+    '@context': SECURITY_CONTEXT_URL,
+    id: publicKey.controller,
+    publicKey: [publicKeyDocument],
+    assertionMethod: [publicKeyDocument.id],
+  };
+
+  const { controller: controllerUrl, id: publicKeyUrl } = publicKey;
+
+  const documents = {
+    [publicKeyUrl]: publicKeyDocument,
+    [controllerUrl]: controllerDocument,
+    [CREDENTIAL_CONTEXT_URL]: CREDENTIAL_CONTEXT,
+    [SCHEMA_CONTEXT_URL]: SCHEMA_CONTEXT,
+  };
+
+  const documentLoader = createDocumentLoader(documents);
+
+  return documentLoader;
+};

--- a/packages/jsonld/tests/signature.test.ts
+++ b/packages/jsonld/tests/signature.test.ts
@@ -1,0 +1,40 @@
+import { signRsaSignature, verifyRsaSignature, generateRsaKeyPair } from '../src';
+import { createDocumentLoaderByMetadata } from './mock/documentLoader';
+
+describe('signing credential', () => {
+  let signed: any;
+  let documentLoader: any;
+
+  beforeAll(async () => {
+    const { publicKeyPem, privateKeyPem } = generateRsaKeyPair();
+
+    const credential = {
+      '@context': ['https://www.w3.org/2018/credentials/v1', 'https://schema.org/'],
+      id: 'http://example.edu/credentials/3732',
+      type: ['VerifiableCredential'],
+      credentialSubject: {
+        id: 'did:example:ebfeb1f712ebc6f1c276e12ec21',
+        alumniOf: '<span lang=\'en\'>Example University</span>',
+      },
+    };
+
+    const publicKey = {
+      id: 'https://example.com/i/alice/keys/1',
+      type: 'RsaVerificationKey2018',
+      controller:
+        'did:tangleid:MoWYKbBfezWbsTkYAngUu523F8YQgHfARhWWsTFSN2U45eAMpsSx3DnrV4SyZHCFuyDqjvQdg7',
+      publicKeyPem,
+    };
+
+    documentLoader = createDocumentLoaderByMetadata(publicKey);
+
+    signed = await signRsaSignature(credential, publicKey, privateKeyPem, {
+      documentLoader,
+    });
+  });
+
+  it('signature verification MUST be true', async () => {
+    const verified = await verifyRsaSignature(signed, { documentLoader });
+    expect(verified).toBe(true);
+  });
+});

--- a/packages/types.ts
+++ b/packages/types.ts
@@ -20,6 +20,12 @@ export type IriProviders = {
   [index: string]: string;
 };
 
+/* Crypto */
+export type RsaKeyPair = {
+  publicKeyPem: PublicKeyPem;
+  privateKeyPem: PrivateKeyPem;
+};
+
 export type PublicKeyPem = string;
 export type PublicKeyMeta = {
   id: string;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2072,7 +2072,7 @@ balanced-match@^1.0.0:
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
   integrity sha1-ibTRmasr7kneFk6gK4nORi1xt2c=
 
-base-x@^3.0.4:
+base-x@^3.0.2, base-x@^3.0.4:
   version "3.0.5"
   resolved "https://registry.yarnpkg.com/base-x/-/base-x-3.0.5.tgz#d3ada59afed05b921ab581ec3112e6444ba0795a"
   integrity sha512-C3picSgzPSLE+jW3tcBzJoGwitOtazb5B+5YmAxZm2ybmTi9LNgAtDO/jjVEBZwHoXmDBZ9m/IELj3elJVRBcA==
@@ -2088,6 +2088,18 @@ base64-js@^1.0.2:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.3.0.tgz#cab1e6118f051095e58b5281aea8c1cd22bfc0e3"
   integrity sha512-ccav/yGvoa80BQDljCxsmmQ3Xvx60/UpBIij5QN21W3wBi/hhIC9OoO+KLpu9IJTS9j4DRVJ3aDDF9cMSoa2lw==
+
+base64url-universal@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/base64url-universal/-/base64url-universal-1.0.0.tgz#827f28d5c5a2b6b12eba745999e9be69099991f5"
+  integrity sha512-MxtKr4XlDeuOzSRceUAT2otQy3VSVZZ02qfM+8fWCR/nY+l2XjZ/rh/Rw+gSsLvqTKXR/u8dzGHjSUdwS6zhAA==
+  dependencies:
+    base64url "^3.0.0"
+
+base64url@^3.0.0, base64url@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/base64url/-/base64url-3.0.1.tgz#6399d572e2bc3f90a9a8b22d5dbb0a32d33f788d"
+  integrity sha512-ir1UPr3dkwexU7FdV8qBBbNDRUhMmIekYMFZfi+C/sLNnRESKPl23nB9b2pltqfOQNnGzsDdId90AEtG5tCx4A==
 
 base@^0.11.1:
   version "0.11.2"
@@ -2131,6 +2143,24 @@ binary-extensions@^1.0.0:
   resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-1.13.1.tgz#598afe54755b2868a5330d2aff9d4ebb53209b65"
   integrity sha512-Un7MIEDdUC5gNpcGDV97op1Ywk748MpHcFTHoYs6qnj1Z3j7I53VG3nwZhKzoBZmbdRNnb6WRdFlwl7tSDuZGw==
 
+bitcore-lib@^0.13.7:
+  version "0.13.19"
+  resolved "https://registry.yarnpkg.com/bitcore-lib/-/bitcore-lib-0.13.19.tgz#48af1e9bda10067c1ab16263472b5add2000f3dc"
+  integrity sha1-SK8em9oQBnwasWJjRyta3SAA89w=
+  dependencies:
+    bn.js "=2.0.4"
+    bs58 "=2.0.0"
+    buffer-compare "=1.0.0"
+    elliptic "=3.0.3"
+    inherits "=2.0.1"
+    lodash "=3.10.1"
+
+"bitcore-message@github:CoMakery/bitcore-message#dist":
+  version "1.0.2"
+  resolved "https://codeload.github.com/CoMakery/bitcore-message/tar.gz/8799cc327029c3d34fc725f05b2cf981363f6ebf"
+  dependencies:
+    bitcore-lib "^0.13.7"
+
 blob@0.0.5:
   version "0.0.5"
   resolved "https://registry.yarnpkg.com/blob/-/blob-0.0.5.tgz#d680eeef25f8cd91ad533f5b01eed48e64caf683"
@@ -2147,6 +2177,16 @@ bluebird@^3.5.1, bluebird@^3.5.3, bluebird@~3.5.0:
   version "3.5.4"
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.5.4.tgz#d6cc661595de30d5b3af5fcedd3c0b3ef6ec5714"
   integrity sha512-FG+nFEZChJrbQ9tIccIfZJBz3J7mLrAhxakAbnrJWn8d7aKOC+LWifa0G+p4ZqKp4y13T7juYvdhq9NzKdsrjw==
+
+bn.js@=2.0.4:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-2.0.4.tgz#220a7cd677f7f1bfa93627ff4193776fe7819480"
+  integrity sha1-Igp81nf38b+pNif/QZN3b+eBlIA=
+
+bn.js@^2.0.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-2.2.0.tgz#12162bc2ae71fc40a5626c33438f3a875cd37625"
+  integrity sha1-EhYrwq5x/EClYmwzQ486h1zTdiU=
 
 brace-expansion@^1.1.7:
   version "1.1.11"
@@ -2171,6 +2211,11 @@ braces@^2.3.1, braces@^2.3.2:
     snapdragon-node "^2.0.1"
     split-string "^3.0.2"
     to-regex "^3.0.1"
+
+brorand@^1.0.1:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/brorand/-/brorand-1.1.0.tgz#12c25efe40a45e3c323eb8675a0a0ce57b22371f"
+  integrity sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8=
 
 browser-process-hrtime@^0.1.2:
   version "0.1.3"
@@ -2200,6 +2245,18 @@ bs-logger@0.x:
   dependencies:
     fast-json-stable-stringify "2.x"
 
+bs58@=2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/bs58/-/bs58-2.0.0.tgz#72b713bed223a0ac518bbda0e3ce3f4817f39eb5"
+  integrity sha1-crcTvtIjoKxRi72g484/SBfznrU=
+
+bs58@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/bs58/-/bs58-4.0.1.tgz#be161e76c354f6f788ae4071f63f34e8c4f0a42a"
+  integrity sha1-vhYedsNU9veIrkBx9j806MTwpCo=
+  dependencies:
+    base-x "^3.0.2"
+
 bser@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/bser/-/bser-2.0.0.tgz#9ac78d3ed5d915804fd87acb158bc797147a1719"
@@ -2211,6 +2268,11 @@ btoa-lite@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/btoa-lite/-/btoa-lite-1.0.0.tgz#337766da15801210fdd956c22e9c6891ab9d0337"
   integrity sha1-M3dm2hWAEhD92VbCLpxokaudAzc=
+
+buffer-compare@=1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/buffer-compare/-/buffer-compare-1.0.0.tgz#acaa7a966e98eee9fae14b31c39a5f158fb3c4a2"
+  integrity sha1-rKp6lm6Y7un64Usxw5pfFY+zxKI=
 
 buffer-from@1.x, buffer-from@^1.0.0:
   version "1.1.1"
@@ -2904,6 +2966,16 @@ crypto-js@^3.1.9-1:
   resolved "https://registry.yarnpkg.com/crypto-js/-/crypto-js-3.1.9-1.tgz#fda19e761fc077e01ffbfdc6e9fdfc59e8806cd8"
   integrity sha1-/aGedh/Ad+Af+/3G6f38WeiAbNg=
 
+crypto-ld@^3.0.0:
+  version "3.5.2"
+  resolved "https://registry.yarnpkg.com/crypto-ld/-/crypto-ld-3.5.2.tgz#4abe86891f2ccfe426e1b1f9d9e5bc5660bd9946"
+  integrity sha512-iW1hNxG86hbLZQQ3ENQvhJoeN66qOvvgfP/TYCYjq6Ag+6nrg/uUXWI2lkmr6+ne/Fk69fLfTB6G1LKY2WiIjg==
+  dependencies:
+    base64url-universal "^1.0.0"
+    bs58 "^4.0.1"
+    node-forge "^0.8.0"
+    sodium-native "^2.3.0"
+
 cssom@0.3.x, "cssom@>= 0.3.2 < 0.4.0":
   version "0.3.6"
   resolved "https://registry.yarnpkg.com/cssom/-/cssom-0.3.6.tgz#f85206cee04efa841f3c5982a74ba96ab20d65ad"
@@ -3228,6 +3300,16 @@ elegant-spinner@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/elegant-spinner/-/elegant-spinner-1.0.1.tgz#db043521c95d7e303fd8f345bedc3349cfb0729e"
   integrity sha1-2wQ1IcldfjA/2PNFvtwzSc+wcp4=
+
+elliptic@=3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/elliptic/-/elliptic-3.0.3.tgz#865c9b420bfbe55006b9f969f97a0d2c44966595"
+  integrity sha1-hlybQgv75VAGuflp+XoNLESWZZU=
+  dependencies:
+    bn.js "^2.0.0"
+    brorand "^1.0.1"
+    hash.js "^1.0.0"
+    inherits "^2.0.1"
 
 enabled@1.0.x:
   version "1.0.2"
@@ -3986,6 +4068,14 @@ has@^1.0.1, has@^1.0.3:
   dependencies:
     function-bind "^1.1.1"
 
+hash.js@^1.0.0:
+  version "1.1.7"
+  resolved "https://registry.yarnpkg.com/hash.js/-/hash.js-1.1.7.tgz#0babca538e8d4ee4a0f8988d68866537a003cf42"
+  integrity sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==
+  dependencies:
+    inherits "^2.0.3"
+    minimalistic-assert "^1.0.1"
+
 hosted-git-info@^2.1.4, hosted-git-info@^2.6.0:
   version "2.7.1"
   resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.7.1.tgz#97f236977bd6e125408930ff6de3eec6281ec047"
@@ -4139,7 +4229,12 @@ inherits@2, inherits@^2.0.1, inherits@^2.0.3, inherits@~2.0.0, inherits@~2.0.3:
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de"
   integrity sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=
 
-ini@^1.3.2, ini@^1.3.4, ini@~1.3.0:
+inherits@=2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.1.tgz#b17d08d326b4423e568eff719f91b0b1cbdf69f1"
+  integrity sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE=
+
+ini@^1.3.2, ini@^1.3.4, ini@^1.3.5, ini@~1.3.0:
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.5.tgz#eee25f56db1c9ec6085e0c22778083f596abf927"
   integrity sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==
@@ -5104,7 +5199,20 @@ jsonfile@^4.0.0:
   optionalDependencies:
     graceful-fs "^4.1.6"
 
-jsonld@^1.6.0:
+jsonld-signatures@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/jsonld-signatures/-/jsonld-signatures-4.1.1.tgz#0fb5701dd7d58df98f45432b392062205acd5be2"
+  integrity sha512-6Z1rZlX82EN76c0VkpwvwLOtry3zL5TeiJvAVD5xUwNzwGsumrbrJEMlPXgOQ2InVnUflzFhZNiz+kw22QEJnQ==
+  dependencies:
+    base64url "^3.0.1"
+    bitcore-message "github:CoMakery/bitcore-message#dist"
+    bs58 "^4.0.1"
+    crypto-ld "^3.0.0"
+    jsonld "^1.5.1"
+    node-forge "^0.8.0"
+    serialize-error "^4.1.0"
+
+jsonld@^1.5.1, jsonld@^1.6.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/jsonld/-/jsonld-1.6.0.tgz#faf968a35e47ababe5b79a0309ee67155a5a8832"
   integrity sha512-gtbEplGXOgSrD7fP0vCmZoYX35MIQqFrpiMfJkEs9KwT7+bNzEd9y9gAUK8SGYXIYJISQCWNU5/eSDPKKxXeHw==
@@ -5424,6 +5532,11 @@ lodash.uniq@^4.5.0:
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
   integrity sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=
 
+lodash@=3.10.1:
+  version "3.10.1"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-3.10.1.tgz#5bf45e8e49ba4189e17d482789dfd15bd140b7b6"
+  integrity sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=
+
 lodash@^4.17.11, lodash@^4.17.5, lodash@^4.2.1:
   version "4.17.11"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
@@ -5692,6 +5805,11 @@ mimic-fn@^2.0.0:
   resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-2.1.0.tgz#7ed2c2ccccaf84d3ffcb7a69b57711fc2083401b"
   integrity sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==
 
+minimalistic-assert@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz#2e194de044626d4a10e7f7fbc00ce73e83e4d5c7"
+  integrity sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==
+
 minimatch@^3.0.0, minimatch@^3.0.3, minimatch@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083"
@@ -5820,7 +5938,7 @@ mute-stream@~0.0.4:
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.8.tgz#1630c42b2251ff81e2a283de96a5497ea92e5e0d"
   integrity sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==
 
-nan@^2.9.2:
+nan@^2.4.0, nan@^2.9.2:
   version "2.13.2"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.13.2.tgz#f51dc7ae66ba7d5d55e1e6d4d8092e802c9aefe7"
   integrity sha512-TghvYc72wlMGMVMluVo9WRJc0mB8KxxF/gZ4YYFy7V2ZQX9l7rgbPg7vjS9mt6U5HXODVFVI2bOduCzwOMv/lw==
@@ -5880,10 +5998,15 @@ node-fetch@2.3.0, node-fetch@^2.3.0:
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.3.0.tgz#1a1d940bbfb916a1d3e0219f037e89e71f8c5fa5"
   integrity sha512-MOd8pV3fxENbryESLgVIeaGKrdl+uaYhCSSVkjeOb/31/njTpcis5aWfdqgNlHIrKOLRbMnfPINPOML2CIFeXA==
 
-node-forge@^0.8.1, node-forge@^0.8.2:
+node-forge@^0.8.0, node-forge@^0.8.1, node-forge@^0.8.2:
   version "0.8.2"
   resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-0.8.2.tgz#b4bcc59fb12ce77a8825fc6a783dfe3182499c5a"
   integrity sha512-mXQ9GBq1N3uDCyV1pdSzgIguwgtVpM7f5/5J4ipz12PKWElmPpVWLDuWl8iXmhysr21+WmX/OJ5UKx82wjomgg==
+
+node-gyp-build@^3.0.0:
+  version "3.9.0"
+  resolved "https://registry.yarnpkg.com/node-gyp-build/-/node-gyp-build-3.9.0.tgz#53a350187dd4d5276750da21605d1cb681d09e25"
+  integrity sha512-zLcTg6P4AbcHPq465ZMFNXx7XpKKJh+7kkN699NiQWisR2uWYOWNWqRHAmbnmKiL4e9aLSlmy5U7rEMUXV59+A==
 
 node-gyp@^3.8.0:
   version "3.8.0"
@@ -7207,6 +7330,13 @@ semver@~5.3.0:
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.3.0.tgz#9b2ce5d3de02d17c6012ad326aa6b4d0cf54f94f"
   integrity sha1-myzl094C0XxgEq0yaqa00M9U+U8=
 
+serialize-error@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/serialize-error/-/serialize-error-4.1.0.tgz#63e1e33ede20bcd89d9f0528ea4c15fbf0f2b78a"
+  integrity sha512-5j9GgyGsP9vV9Uj1S0lDCvlsd+gc2LEPVK7HHHte7IyPwOD4lVQFeaX143gx3U5AnoCi+wbcb3mvaxVysjpxEw==
+  dependencies:
+    type-fest "^0.3.0"
+
 set-blocking@^2.0.0, set-blocking@~2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/set-blocking/-/set-blocking-2.0.0.tgz#045f9782d011ae9a6803ddd382b24392b3d890f7"
@@ -7365,6 +7495,15 @@ socks@~2.3.2:
   dependencies:
     ip "^1.1.5"
     smart-buffer "4.0.2"
+
+sodium-native@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/sodium-native/-/sodium-native-2.3.0.tgz#40cee5f504bb5f6196cc40c42748162d66ec2598"
+  integrity sha512-TYId1m2iLXXot2Q3KA6u8Ti9pmL24T2cm8nb9OUGFFmTxdw4I+vnkjcPVA4LT1acw+A86iJkEn+8iV51jcTWUg==
+  dependencies:
+    ini "^1.3.5"
+    nan "^2.4.0"
+    node-gyp-build "^3.0.0"
 
 sort-array@^2.0.0:
   version "2.0.0"
@@ -7984,6 +8123,11 @@ type-check@~0.3.2:
   integrity sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=
   dependencies:
     prelude-ls "~1.1.2"
+
+type-fest@^0.3.0:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.3.1.tgz#63d00d204e059474fe5e1b7c011112bbd1dc29e1"
+  integrity sha512-cUGJnCdr4STbePCgqNFbpVNCepa+kAVohJs1sLhxzdH+gnEoOd8VhbYa7pD3zZYGiURWM2xzEII3fQcRizDkYQ==
 
 typedarray@^0.0.6:
   version "0.0.6"


### PR DESCRIPTION
To signing the credential and verifying the signature, the following
utilities are added:
 - generateRsaKeyPair
 - signRsaSignature
 - verifyRsaSignature

Since the "jsonld-signatures" uses the "sodium-native" package, and
"sodium-native" native codes cannot build with the latest stable
Node.js on the Travis CI, so modify Travis CI configuration file
".travis.yml" to use the latest LTS Node.js instead.

See also:
 - https://docs.travis-ci.com/user/languages/javascript-with-nodejs/
 - https://github.com/sodium-friends/sodium-native/issues/95