### PR TITLE
Fix exceeds maximum line length

### DIFF
--- a/packages/did/README.md
+++ b/packages/did/README.md
@@ -121,4 +121,5 @@ Register the TangleID DID(Decentralized Identifier) on the IOTA/Tangle.
 
 Resolve the DID Document from the DID(Decentralized Identifier).
 
-**Returns**: <code>Promise</code> - - Promise object represents the [DID Document](https://w3c-ccg.github.io/did-spec/#did-documents).  
+**Returns**: <code>Promise</code> - Promise object represents the
+  [DID Document](https://w3c-ccg.github.io/did-spec/#did-documents).  

--- a/packages/did/src/IdenityRegistry.ts
+++ b/packages/did/src/IdenityRegistry.ts
@@ -65,7 +65,8 @@ export default class IdenityRegistry {
    * @param {string} network - The network identitfer.
    * @param {string} seed - The seed of the MAM channel.
    * @param {string[]} publicKeys - PEM-formatted public Keys.
-   * @returns {Promise} Promise object represents the result. The result conatains DID `did` and DID document `document`.
+   * @returns {Promise} Promise object represents the result. The result
+   *   conatains DID `did` and DID document `document`.
    */
   publish = async (
     network: NetworkIdentifer,
@@ -91,7 +92,8 @@ export default class IdenityRegistry {
   /**
    * Fetch DID document by DID.
    * @param {string} did - The DID of DID document.
-   * @returns {Promise<string>} Promise object represents the {@link https://w3c-ccg.github.io/did-spec/#did-documents DID Document}.
+   * @returns {Promise<string>} Promise object represents the
+   *   {@link https://w3c-ccg.github.io/did-spec/#did-documents DID Document}.
    */
   fetch = async (did: Did): Promise<DidDocument> => {
     const { network, address } = decodeFromDid(did);

--- a/packages/did/src/did.ts
+++ b/packages/did/src/did.ts
@@ -8,7 +8,8 @@ import { Did, MnidModel, PublicKeyPem, PublicKeyMeta } from '../../types';
  * @param {object} params - Encode parameters.
  * @param {string} params.network - Network identifier.
  * @param {string} params.address - Address in 81-trytes format.
- * @returns {string} TangleID which follow the DID scheme {@link https://w3c-ccg.github.io/did-spec/#the-generic-did-scheme DID Document}.
+ * @returns {string} TangleID which follow the DID scheme
+ *   @link https://w3c-ccg.github.io/did-spec/#the-generic-did-scheme DID Document}.
  */
 export const encodeToDid = ({ network, address }: MnidModel): Did => {
   const mnid = encodeToMnid({
@@ -23,7 +24,8 @@ export const encodeToDid = ({ network, address }: MnidModel): Did => {
 /**
  * Decode infromation of network and address from TangleID.
  * @function decodeFromDid
- * @param {string} tangleid - TangleID which follow the DID scheme {@link https://w3c-ccg.github.io/did-spec/#the-generic-did-scheme DID Document}.
+ * @param {string} tangleid - TangleID which follow the DID scheme
+ *   {@link https://w3c-ccg.github.io/did-spec/#the-generic-did-scheme DID Document}.
  * @returns {{network: string, address: string}}} The infromation of network and address.
  */
 export const decodeFromDid = (tangleid: Did): MnidModel => {

--- a/packages/did/src/resolver.ts
+++ b/packages/did/src/resolver.ts
@@ -7,7 +7,8 @@ import { Did } from '../../types';
  * @method resolver
  * @param {String} did - The DID to be resolved.
  * @param {IdenityRegistry} registry - The registry used to maintain the identity.
- * @return {Promise} - Promise object represents the {@link https://w3c-ccg.github.io/did-spec/#did-documents DID Document}.
+ * @returns {Promise} Promise object represents the
+ *   {@link https://w3c-ccg.github.io/did-spec/#did-documents DID Document}.
  */
 const resolver = async (did: Did, registry = new IdenityRegistry()) => {
   const document = await registry.fetch(did);


### PR DESCRIPTION
To fix code documentation exceeds maximum line length of 120, add the
line break to code documentation and regenerate the README document.