### PR TITLE
Fix Travis CI doesn't stop when lint failed

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   ],
   "scripts": {
     "init": "yarn install --ignore-engines && lerna bootstrap",
-    "lint": "tslint --force --format verbose ./packages/*/src/**/*.ts",
+    "lint": "tslint --format verbose ./packages/*/src/**/*.ts",
     "test": "jest",
     "docs": "yarn run build && lerna exec -- yarn run docs",
     "clean": "lerna exec --parallel -- rimraf lib typings",


### PR DESCRIPTION
The Travis CI doesn't stop when lint failed, because of lint script
uses the "--force" parameter that will always return exit code 0.

To resolve this problem, remove the "--force" parameter from the lint
script.

See also: https://palantir.github.io/tslint/usage/cli/