### PR TITLE
Add @tangleid/core package (#128)

### DIFF
--- a/packages/core/LICENSE
+++ b/packages/core/LICENSE
@@ -1,0 +1,22 @@
+The MIT License (MIT)
+
+Copyright (C) 2018-2019 BiiLabs Co., Ltd. and Contributors
+All Rights Reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -1,0 +1,98 @@
+# @tangleid/core
+
+Core functionality to interact with TangleID. Includes methods for:
+- Registering and resolving identity
+- Signing JSON-LD document
+- Verifying JSON-LD document signature
+
+## Installation
+
+Install using [npm](https://www.npmjs.org/):
+
+```shell
+npm install @tangleid/core
+```
+
+or using [yarn](https://yarnpkg.com/):
+
+```shell
+yarn add @tangleid/core
+```
+
+## API Reference
+
+
+* [core](#module_core)
+
+    * [.composeAPI([settings])](#module_core.composeAPI)
+
+    * [.registerIdentity(network, seed, publicKeys)](#module_core.registerIdentity)
+
+    * [.resolveIdentity(did)](#module_core.resolveIdentity)
+
+    * [.signRsaSignature(document, publicKey, privateKeyPem)](#module_core.signRsaSignature)
+
+    * [.verifyRsaSignature(document)](#module_core.verifyRsaSignature)
+
+
+<a name="module_core.composeAPI"></a>
+
+### *core*.composeAPI([settings])
+
+| Param | Type | Default | Description |
+| --- | --- | --- | --- |
+| [settings] | <code>object</code> | <code>{}</code> | Connection settings |
+| [params.providers] | <code>object</code> |  | The IRI node providers in differenct network. |
+
+Composes API object from it's components
+
+<a name="module_core.registerIdentity"></a>
+
+### *core*.registerIdentity(network, seed, publicKeys)
+
+| Param | Type | Description |
+| --- | --- | --- |
+| network | <code>string</code> | The network identitfer. |
+| seed | <code>string</code> | The seed of the MAM channel. |
+| publicKeys | <code>Array.&lt;string&gt;</code> | PEM-formatted public Keys. |
+
+Publish the DID document to the Tangle MAM channel with specific network.
+
+**Returns**: <code>Promise.&lt;object&gt;</code> - Promise object represents the result. The result
+  conatains DID `did` and DID document `document`.  
+<a name="module_core.resolveIdentity"></a>
+
+### *core*.resolveIdentity(did)
+
+| Param | Type | Description |
+| --- | --- | --- |
+| did | <code>string</code> | The DID of DID document. |
+
+Fetch DID document by DID.
+
+**Returns**: <code>Promise.&lt;object&gt;</code> - Promise object represents the
+  [DID Document](https://w3c-ccg.github.io/did-spec/#did-documents).  
+<a name="module_core.signRsaSignature"></a>
+
+### *core*.signRsaSignature(document, publicKey, privateKeyPem)
+
+| Param | Type | Description |
+| --- | --- | --- |
+| document | <code>object</code> | JSON-LD document to be signed. |
+| publicKey | <code>PublicKeyMeta</code> | Public key metadata. |
+| privateKeyPem | <code>string</code> | PEM-formatted private key. |
+
+Sign JSON-LD document with RSA signature suite.
+
+**Returns**: <code>Promise.&lt;object&gt;</code> - Promise object represents signed JSON-LD document.  
+<a name="module_core.verifyRsaSignature"></a>
+
+### *core*.verifyRsaSignature(document)
+
+| Param | Type | Description |
+| --- | --- | --- |
+| document | <code>object</code> | JSON-LD document to be verify. |
+
+Verify JSON-LD document signature.
+
+**Returns**: <code>Promise.&lt;boolean&gt;</code> - Promise object represents verification result.  

--- a/packages/core/README.template
+++ b/packages/core/README.template
@@ -1,0 +1,28 @@
+# @tangleid/core
+
+Core functionality to interact with TangleID. Includes methods for:
+- Registering and resolving identity
+- Signing JSON-LD document
+- Verifying JSON-LD document signature
+
+## Installation
+
+Install using [npm](https://www.npmjs.org/):
+
+```shell
+npm install @tangleid/core
+```
+
+or using [yarn](https://yarnpkg.com/):
+
+```shell
+yarn add @tangleid/core
+```
+
+## API Reference
+
+{{#module name="core"~}}
+{{>body~}}
+{{>member-index~}}
+{{>members~}}
+{{/module~}}

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@tangleid/core",
+  "version": "1.1.1",
+  "description": "Core functionality to interact with TangleID",
+  "author": "TangleID Developers",
+  "main": "lib/index.js",
+  "scripts": {
+    "test": "jest -c ../../jest.config.js",
+    "build": "tsc",
+    "docs": "tsc && jsdoc2md --no-cache --plugin dmd-clear -t README.template --files './lib/**/*.js' > README.md"
+  },
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/TangleID/tangleid-core/tree/master/packages/core"
+  },
+  "dependencies": {
+    "@tangleid/did": "1.1.1",
+    "@tangleid/jsonld": "1.0.2",
+    "jsonld": "^1.6.0"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/core/src/composeAPI.ts
+++ b/packages/core/src/composeAPI.ts
@@ -1,0 +1,37 @@
+import { IdenityRegistry } from '@tangleid/did';
+import { IriProviders } from '../../types';
+
+import { createDocumentLoader } from './jsonld/documentLoader';
+
+import { createRegisterIdentity } from './createRegisterIdentity';
+import { createResolveIdentity } from './createResolveIdentity';
+import { createSignRsaSignature } from './createSignRsaSignature';
+import { createVerifyRsaSignature } from './createVerifyRsaSignature';
+
+export type Settings = {
+  providers?: IriProviders;
+};
+
+/**
+ * Composes API object from it's components
+ *
+ * @function composeAPI
+ *
+ * @memberof module:core
+ *
+ * @param {object} [settings={}] - Connection settings
+ * @param {object} [params.providers] - The IRI node providers in differenct network.
+ *
+ * @return {API}
+ */
+export const composeAPI = (settings: Partial<Settings> = {}) => {
+  const idenityRegistry = new IdenityRegistry({ providers: settings.providers });
+  const documentLoader = createDocumentLoader(idenityRegistry);
+
+  return {
+    registerIdentity: createRegisterIdentity(idenityRegistry),
+    resolveIdentity: createResolveIdentity(idenityRegistry),
+    signRsaSignature: createSignRsaSignature(documentLoader),
+    verifyRsaSignature: createVerifyRsaSignature(documentLoader),
+  };
+};

--- a/packages/core/src/createRegisterIdentity.ts
+++ b/packages/core/src/createRegisterIdentity.ts
@@ -1,0 +1,23 @@
+import { IdenityRegistry } from '@tangleid/did';
+
+import { NetworkIdentifer, Seed, PublicKeyPem } from '../../types';
+
+export const createRegisterIdentity = (registry: IdenityRegistry) => {
+  /**
+   * Publish the DID document to the Tangle MAM channel with specific network.
+   *
+   * @memberof module:core
+   *
+   * @function registerIdentity
+   * @param {string} network - The network identitfer.
+   * @param {string} seed - The seed of the MAM channel.
+   * @param {string[]} publicKeys - PEM-formatted public Keys.
+   * @returns {Promise<object>} Promise object represents the result. The result
+   *   conatains DID `did` and DID document `document`.
+   */
+  return async (network: NetworkIdentifer, seed: Seed, publicKeys: PublicKeyPem[] = []) => {
+    const didDocument = await registry.publish(network, seed, publicKeys);
+
+    return didDocument;
+  };
+};

--- a/packages/core/src/createResolveIdentity.ts
+++ b/packages/core/src/createResolveIdentity.ts
@@ -1,0 +1,21 @@
+import { IdenityRegistry } from '@tangleid/did';
+
+import { Did } from '../../types';
+
+export const createResolveIdentity = (registry: IdenityRegistry) => {
+  /**
+   * Fetch DID document by DID.
+   *
+   * @memberof module:core
+   *
+   * @function resolveIdentity
+   * @param {string} did - The DID of DID document.
+   * @returns {Promise<object>} Promise object represents the
+   *   {@link https://w3c-ccg.github.io/did-spec/#did-documents DID Document}.
+   */
+  return async (did: Did) => {
+    const didDocument = await registry.fetch(did);
+
+    return didDocument;
+  };
+};

--- a/packages/core/src/createSignRsaSignature.ts
+++ b/packages/core/src/createSignRsaSignature.ts
@@ -1,0 +1,23 @@
+import { signRsaSignature } from '@tangleid/jsonld';
+import { PublicKeyMeta, PrivateKeyPem } from '../..//types';
+
+export const createSignRsaSignature = (documentLoader: any) => {
+  /**
+   * Sign JSON-LD document with RSA signature suite.
+   *
+   * @memberof module:core
+   *
+   * @function signRsaSignature
+   * @param {object} document - JSON-LD document to be signed.
+   * @param {PublicKeyMeta} publicKey - Public key metadata.
+   * @param {string} privateKeyPem - PEM-formatted private key.
+   * @returns {Promise<object>} Promise object represents signed JSON-LD document.
+   */
+  return async (document: any, publicKey: PublicKeyMeta, privateKeyPem: PrivateKeyPem) => {
+    const documentSigned = await signRsaSignature(document, publicKey, privateKeyPem, {
+      documentLoader,
+    });
+
+    return documentSigned;
+  };
+};

--- a/packages/core/src/createVerifyRsaSignature.ts
+++ b/packages/core/src/createVerifyRsaSignature.ts
@@ -1,0 +1,20 @@
+import { verifyRsaSignature } from '@tangleid/jsonld';
+
+export const createVerifyRsaSignature = (documentLoader: any) => {
+  /**
+   * Verify JSON-LD document signature.
+   *
+   * @memberof module:core
+   *
+   * @function verifyRsaSignature
+   * @param {object} document - JSON-LD document to be verify.
+   * @returns {Promise<boolean>} Promise object represents verification result.
+   */
+  return async (document: any) => {
+    const verified = await verifyRsaSignature(document, {
+      documentLoader,
+    });
+
+    return verified;
+  };
+};

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,0 +1,3 @@
+/** @module core */
+
+export * from './composeAPI';

--- a/packages/core/src/jsonld/documentLoader.ts
+++ b/packages/core/src/jsonld/documentLoader.ts
@@ -1,0 +1,42 @@
+import { IdenityRegistry } from '@tangleid/did';
+// @ts-ignore
+import * as jsonld from 'jsonld';
+// @ts-ignore
+const nodeDocumentLoader = jsonld.documentLoaders.node();
+
+type CachedDocuments = {
+  [index: string]: any;
+};
+
+export const createDocumentLoader = (
+  registry: IdenityRegistry,
+  {
+    documents = {},
+  }: {
+    documents?: CachedDocuments;
+  } = {},
+) => {
+  return async (url: string) => {
+    const context = documents[url];
+    if (context !== undefined) {
+      return {
+        contextUrl: null,
+        documentUrl: url,
+        document: context,
+      };
+    }
+
+    if (url.startsWith('did:tangleid:')) {
+      const document = await registry.fetch(url);
+      return {
+        document,
+        documentUrl: url,
+        contextUrl: null,
+      };
+    }
+
+    const result = await nodeDocumentLoader(url);
+    documents[url] = result.document;
+    return result;
+  };
+};

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "compilerOptions": {
+    "outDir": "lib",
+    "declarationDir": "typings"
+  },
+  "include": ["src"],
+  "extends": "../../tsconfig"
+}


### PR DESCRIPTION
Because TangleId has many packages, it's hard for people to use
TangleID library at first sight.

To make TangleID library easy to use, add the "@tangleid/core" package
as the mainly packages and provide the core functionality:
 - registerIdentity
 - resolveIdentity
 - signRsaSignature
 - verifyRsaSignature