### PR TITLE
Fix append empty alias to context

### DIFF
--- a/packages/credential/src/credential.ts
+++ b/packages/credential/src/credential.ts
@@ -31,7 +31,10 @@ export const generateCredential = ({
   context = [CREDENTIAL_CONTEXT_URL],
   alias = {},
 }: ComposeCredentialParams) => {
-  const contextMerged = [...context, alias];
+  let contextMerged: any = context;
+  if (Object.keys(alias).length > 0) {
+    contextMerged = [...context, alias];
+  }
 
   if (!metadata.type) {
     metadata.type = ['VerifiableCredential'];


### PR DESCRIPTION
The "generateCredential()" should not append the alias to the context
when no alias provided.