### PR TITLE
Rename core API names

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,19 +36,19 @@ import { composeAPI } from '@tangleid/core';
 
 const tid = composeAPI({
   providers: {
-    // mainnet IRI
+    // mainnet
     '0x1': 'http://node.deviceproof.org:14265',
-    // devnet IRI
+    // devnet
     '0x2': 'https://nodes.devnet.thetangle.org:443',
   },
 });
 
-const { seed, did, document } = await tid.registerIdentity({
+const { seed, did, document } = await tid.registerIdentifier({
   network: '0x1',
   publicKey,
 });
 
-const resolved = await tid.resolveIdentity(did);
+const resolved = await tid.resolveIdentifier(did);
 ```
 
 The API Reference can be found in [here](packages/core#api-reference).

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -1,7 +1,7 @@
 # @tangleid/core
 
 Core functionality to interact with TangleID. Includes methods for:
-- Registering and resolving identity
+- Registering and resolving identifier
 - Signing JSON-LD document
 - Verifying JSON-LD document signature
 
@@ -26,9 +26,9 @@ yarn add @tangleid/core
 
     * [.composeAPI([settings])](#module_core.composeAPI)
 
-    * [.registerIdentity(network, seed, publicKeys)](#module_core.registerIdentity)
+    * [.registerIdentifier(network, seed, publicKeys)](#module_core.registerIdentifier)
 
-    * [.resolveIdentity(did)](#module_core.resolveIdentity)
+    * [.resolveIdentifier(did)](#module_core.resolveIdentifier)
 
     * [.signRsaSignature(document, publicKey, privateKeyPem)](#module_core.signRsaSignature)
 
@@ -46,9 +46,9 @@ yarn add @tangleid/core
 
 Composes API object from it's components
 
-<a name="module_core.registerIdentity"></a>
+<a name="module_core.registerIdentifier"></a>
 
-### *core*.registerIdentity(network, seed, publicKeys)
+### *core*.registerIdentifier(network, seed, publicKeys)
 
 | Param | Type | Description |
 | --- | --- | --- |
@@ -60,9 +60,9 @@ Publish the DID document to the Tangle MAM channel with specific network.
 
 **Returns**: <code>Promise.&lt;object&gt;</code> - Promise object represents the result. The result
   conatains DID `did` and DID document `document`.  
-<a name="module_core.resolveIdentity"></a>
+<a name="module_core.resolveIdentifier"></a>
 
-### *core*.resolveIdentity(did)
+### *core*.resolveIdentifier(did)
 
 | Param | Type | Description |
 | --- | --- | --- |

--- a/packages/core/README.template
+++ b/packages/core/README.template
@@ -1,7 +1,7 @@
 # @tangleid/core
 
 Core functionality to interact with TangleID. Includes methods for:
-- Registering and resolving identity
+- Registering and resolving identifier
 - Signing JSON-LD document
 - Verifying JSON-LD document signature
 

--- a/packages/core/src/composeAPI.ts
+++ b/packages/core/src/composeAPI.ts
@@ -3,8 +3,8 @@ import { IriProviders } from '../../types';
 
 import { createDocumentLoader } from './jsonld/documentLoader';
 
-import { createRegisterIdentity } from './createRegisterIdentity';
-import { createResolveIdentity } from './createResolveIdentity';
+import { createRegisterIdentifier } from './createRegisterIdentifier';
+import { createResolveIdentifier } from './createResolveIdentifier';
 import { createSignRsaSignature } from './createSignRsaSignature';
 import { createVerifyRsaSignature } from './createVerifyRsaSignature';
 
@@ -29,8 +29,8 @@ export const composeAPI = (settings: Partial<Settings> = {}) => {
   const documentLoader = createDocumentLoader(idenityRegistry);
 
   return {
-    registerIdentity: createRegisterIdentity(idenityRegistry),
-    resolveIdentity: createResolveIdentity(idenityRegistry),
+    registerIdentifier: createRegisterIdentifier(idenityRegistry),
+    resolveIdentifier: createResolveIdentifier(idenityRegistry),
     signRsaSignature: createSignRsaSignature(documentLoader),
     verifyRsaSignature: createVerifyRsaSignature(documentLoader),
   };

--- a/packages/core/src/createRegisterIdentifier.ts
+++ b/packages/core/src/createRegisterIdentifier.ts
@@ -2,13 +2,13 @@ import { IdenityRegistry } from '@tangleid/did';
 
 import { NetworkIdentifer, Seed, PublicKeyPem } from '../../types';
 
-export const createRegisterIdentity = (registry: IdenityRegistry) => {
+export const createRegisterIdentifier = (registry: IdenityRegistry) => {
   /**
    * Publish the DID document to the Tangle MAM channel with specific network.
    *
    * @memberof module:core
    *
-   * @function registerIdentity
+   * @function registerIdentifier
    * @param {string} network - The network identitfer.
    * @param {string} seed - The seed of the MAM channel.
    * @param {string[]} publicKeys - PEM-formatted public Keys.

--- a/packages/core/src/createResolveIdentifier.ts
+++ b/packages/core/src/createResolveIdentifier.ts
@@ -2,13 +2,13 @@ import { IdenityRegistry } from '@tangleid/did';
 
 import { Did } from '../../types';
 
-export const createResolveIdentity = (registry: IdenityRegistry) => {
+export const createResolveIdentifier = (registry: IdenityRegistry) => {
   /**
    * Fetch DID document by DID.
    *
    * @memberof module:core
    *
-   * @function resolveIdentity
+   * @function resolveIdentifier
    * @param {string} did - The DID of DID document.
    * @returns {Promise<object>} Promise object represents the
    *   {@link https://w3c-ccg.github.io/did-spec/#did-documents DID Document}.

--- a/packages/did/README.md
+++ b/packages/did/README.md
@@ -18,7 +18,7 @@ yarn add @tangleid/did
 
 ## Quick Start
 
-### Register Identity to Mainnet
+### Register Decentralized Identifier for Digital Identity
 
 ```javascript
 const { register } = require('@tangleid/did');
@@ -28,7 +28,7 @@ const publicKey = '-----BEGIN PUBLIC KEY-----//..-----END PUBLIC KEY-----';
 const { did, document, seed } = await register({ seed, network: '0x1', publicKey });
 ```
 
-#### Register Identity with Specific Nodes
+#### Register Decentralized Identifier with Specific IOTA nodes
 
 ```javascript
 import { register, IdenityRegistry } from '@tangleid/did';

--- a/packages/did/README.template
+++ b/packages/did/README.template
@@ -18,7 +18,7 @@ yarn add @tangleid/did
 
 ## Quick Start
 
-### Register Identity to Mainnet
+### Register Decentralized Identifier for Digital Identity
 
 ```javascript
 const { register } = require('@tangleid/did');
@@ -28,7 +28,7 @@ const publicKey = '-----BEGIN PUBLIC KEY-----//..-----END PUBLIC KEY-----';
 const { did, document, seed } = await register({ seed, network: '0x1', publicKey });
 ```
 
-#### Register Identity with Specific Nodes
+#### Register Decentralized Identifier with Specific IOTA nodes
 
 ```javascript
 import { register, IdenityRegistry } from '@tangleid/did';


### PR DESCRIPTION
To use the words more precisely, replace "identity" with "identifier"
in each code documentation and rename the following core API names:
 - registerIdentity() -> registerIdentifier()
 - resolveIdentity() -> resolveIdentifier()