### PR TITLE
Rename generatePublicKeys to createMetaPublicKeys

### DIFF
--- a/packages/did/src/IdenityRegistry.ts
+++ b/packages/did/src/IdenityRegistry.ts
@@ -3,7 +3,7 @@ import * as tic from 'tic.api.js';
 // @ts-ignore
 import * as mamClient from 'mam.tools.js';
 
-import { encodeToDid, decodeFromDid, generatePublicKeys } from './did';
+import { encodeToDid, decodeFromDid, createMetaPublicKeys } from './did';
 import {
   Seed,
   Did,
@@ -81,7 +81,7 @@ export default class IdenityRegistry {
     };
 
     if (publicKeys.length > 0) {
-      document.publicKey = generatePublicKeys(did, publicKeys);
+      document.publicKey = createMetaPublicKeys(did, publicKeys);
     }
 
     await tic.profile.putInfo(ticClient.profile, document);

--- a/packages/did/src/did.ts
+++ b/packages/did/src/did.ts
@@ -36,13 +36,13 @@ export const decodeFromDid = (tangleid: Did): MnidModel => {
 };
 
 /**
- * Generate public keys from PEM-formatted public Keys.
- * @function generatePublicKeys
+ * Create metadata of public keys from PEM-formatted public Keys.
+ * @function createMetaPublicKeys
  * @param {string} controller - DID of the controller.
  * @param {string[]} publicKeyPems - PEM-formatted public Keys.
  * @returns {Object[]} Public keys
  */
-export const generatePublicKeys = (
+export const createMetaPublicKeys = (
   controller: Did,
   publicKeyPems: PublicKeyPem[],
 ): PublicKeyMeta[] => {


### PR DESCRIPTION
Since the "generatePublicKeys()" is generating the public key metadata
array, rename it into "createMetaPublicKeys()".