### PR TITLE
Track code coverage to Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,4 +5,4 @@ install:
   - yarn run init
 script:
   - yarn run lint
-  - yarn run test
+  - yarn run test:coverage

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "init": "yarn install --ignore-engines && lerna bootstrap",
     "lint": "tslint --format verbose ./packages/*/src/**/*.ts",
     "test": "jest",
+    "test:coverage": "jest --verbose --coverage",
     "docs": "yarn run build && lerna exec -- yarn run docs",
     "clean": "lerna exec --parallel -- rimraf lib typings",
     "build": "yarn run clean && lerna exec -- yarn run build",


### PR DESCRIPTION
To track the code coverage to the Travis CI, add test script to show the
code coverage and individual test results, and use it on the Travis CI
configuration.

See also:
 - https://jestjs.io/docs/en/cli#verbose
 - https://jestjs.io/docs/en/cli#coverage