### PR TITLE
refactor(core): Rename DID method name

### DIFF
--- a/packages/core/src/jsonld/documentLoader.ts
+++ b/packages/core/src/jsonld/documentLoader.ts
@@ -26,7 +26,7 @@ export const createDocumentLoader = (
       };
     }
 
-    if (url.startsWith('did:tangleid:')) {
+    if (url.startsWith('did:tangle:')) {
       const document = await registry.fetch(url);
       return {
         document,

--- a/packages/did/src/did.ts
+++ b/packages/did/src/did.ts
@@ -17,7 +17,7 @@ export const encodeToDid = ({ network, address }: MnidModel): Did => {
     network,
     address,
   });
-  const did = `did:tangleid:${mnid}`;
+  const did = `did:tangle:${mnid}`;
 
   return did;
 };

--- a/packages/jsonld/test/signature.test.ts
+++ b/packages/jsonld/test/signature.test.ts
@@ -22,7 +22,7 @@ describe('signing credential', () => {
       id: 'https://example.com/i/alice/keys/1',
       type: 'RsaVerificationKey2018',
       controller:
-        'did:tangleid:MoWYKbBfezWbsTkYAngUu523F8YQgHfARhWWsTFSN2U45eAMpsSx3DnrV4SyZHCFuyDqjvQdg7',
+        'did:tangle:MoWYKbBfezWbsTkYAngUu523F8YQgHfARhWWsTFSN2U45eAMpsSx3DnrV4SyZHCFuyDqjvQdg7',
       publicKeyPem,
     };
 


### PR DESCRIPTION
Because TangleID DID method name is renamed into "tangle" in the
specification, change the implementation to use the same method name.