### PR TITLE
fix(all): Fix missing type declarations

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -4,6 +4,7 @@
   "description": "Core functionality to interact with TangleID",
   "author": "TangleID Developers",
   "main": "lib/index.js",
+  "typings": "typings/core/src",
   "scripts": {
     "test": "jest -c ../../jest.config.js",
     "build": "tsc",

--- a/packages/credential/package.json
+++ b/packages/credential/package.json
@@ -4,6 +4,7 @@
   "description": "Utilities for generating credentials",
   "author": "TangleID Developers",
   "main": "lib/index.js",
+  "typings": "typings/credential/src",
   "scripts": {
     "test": "jest -c ../../jest.config.js",
     "build": "tsc",

--- a/packages/did/package.json
+++ b/packages/did/package.json
@@ -4,6 +4,7 @@
   "description": "Utilities for the coding of decentralized identifiers",
   "author": "TangleID Developers",
   "main": "lib/index.js",
+  "typings": "typings/did/src",
   "scripts": {
     "test": "jest -c ../../jest.config.js",
     "build": "tsc",

--- a/packages/jsonld/package.json
+++ b/packages/jsonld/package.json
@@ -4,6 +4,7 @@
   "description": "Utilities for processing JSON-LD format",
   "author": "TangleID Developers",
   "main": "lib/index.js",
+  "typings": "typings/jsonld/src",
   "scripts": {
     "test": "jest -c ../../jest.config.js",
     "build": "tsc",


### PR DESCRIPTION
The type declaration files are generated after compiling TypeScript
packages, but "package.json" does not mention the location of
type declaration files, it will cause other TypeScript projects
will not be able to recognize our package's types.

To fix this problem, add the missing "typings" field to mention
location of type declaration files.

See also:
https://www.typescriptlang.org/docs/handbook/declaration-files/publishing.html