### PR TITLE
fix(all): Fix generate unnecessary code

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,5 +1,5 @@
 const { pathsToModuleNameMapper } = require('ts-jest/utils');
-const { compilerOptions } = require('./tsconfig');
+const { compilerOptions } = require('./tsconfig.test');
 
 module.exports = {
   preset: 'ts-jest',

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -7,6 +7,9 @@
     "declaration": true,
     "sourceMap": true,
     "moduleResolution": "node",
-    "baseUrl": "."
+    "baseUrl": ".",
+    "paths": {
+      "@tangleid/*": ["./packages/*/src"]
+    }
   }
 }


### PR DESCRIPTION
Using the path mapping feature in the "tsconfig.json" will cause
TypeScript compiler treats these package as source files and compile
them to generate unnecessary JavaScript code.

We need the path mapping feature to run the test cases without
compiling any TypeScript source code, so split the "tsconfig.json"
for different usages.

 - "tsconfig.json" compiling the source code (w/o path mapping)
 - "tsconfig.test.json" running the test case (w path mapping)