### PR TITLE
ci: Add build test to Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,3 +6,4 @@ install:
 script:
   - yarn run lint
   - yarn run test:coverage
+  - yarn run build


### PR DESCRIPTION
To make sure the code can be built successfully, modify the Travis CI
configuration to run the build test when each code changes.