### PR TITLE
fix(all): Fix generate unnecessary code

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -6,5 +6,10 @@ module.exports = {
   testEnvironment: 'node',
   moduleNameMapper: pathsToModuleNameMapper(compilerOptions.paths, {
     prefix: '<rootDir>/'
-  })
+  }),
+  globals: {
+    'ts-jest': {
+      tsConfig: 'tsconfig.json'
+    }
+  }
 };

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -7,7 +7,7 @@
   "typings": "typings/core/src",
   "scripts": {
     "test": "jest -c ../../jest.config.js",
-    "build": "tsc",
+    "build": "tsc -p tsconfig.release.json",
     "docs": "tsc && jsdoc2md --no-cache --plugin dmd-clear -t README.template --files './lib/**/*.js' > README.md"
   },
   "license": "MIT",

--- a/packages/core/tsconfig.release.json
+++ b/packages/core/tsconfig.release.json
@@ -4,5 +4,5 @@
     "declarationDir": "typings"
   },
   "include": ["src"],
-  "extends": "../../tsconfig"
+  "extends": "../../tsconfig.release"
 }

--- a/packages/credential/package.json
+++ b/packages/credential/package.json
@@ -7,7 +7,7 @@
   "typings": "typings/credential/src",
   "scripts": {
     "test": "jest -c ../../jest.config.js",
-    "build": "tsc",
+    "build": "tsc -p tsconfig.release.json",
     "docs": "tsc && jsdoc2md --no-cache --plugin dmd-clear -t README.template --files './lib/**/*.js' > README.md"
   },
   "license": "MIT",

--- a/packages/credential/tsconfig.release.json
+++ b/packages/credential/tsconfig.release.json
@@ -4,5 +4,5 @@
     "declarationDir": "typings"
   },
   "include": ["src"],
-  "extends": "../../tsconfig"
+  "extends": "../../tsconfig.release"
 }

--- a/packages/did/package.json
+++ b/packages/did/package.json
@@ -7,7 +7,7 @@
   "typings": "typings/did/src",
   "scripts": {
     "test": "jest -c ../../jest.config.js",
-    "build": "tsc",
+    "build": "tsc -p tsconfig.release.json",
     "docs": "jsdoc2md --no-cache --plugin dmd-clear -t README.template --files './lib/**/*.js' > README.md"
   },
   "license": "MIT",

--- a/packages/did/tsconfig.release.json
+++ b/packages/did/tsconfig.release.json
@@ -4,5 +4,5 @@
     "declarationDir": "typings"
   },
   "include": ["src"],
-  "extends": "../../tsconfig"
+  "extends": "../../tsconfig.release"
 }

--- a/packages/jsonld/package.json
+++ b/packages/jsonld/package.json
@@ -7,7 +7,7 @@
   "typings": "typings/jsonld/src",
   "scripts": {
     "test": "jest -c ../../jest.config.js",
-    "build": "tsc",
+    "build": "tsc -p tsconfig.release.json",
     "docs": "tsc && jsdoc2md --no-cache --plugin dmd-clear -t README.template --files './lib/**/*.js' > README.md"
   },
   "license": "MIT",

--- a/packages/jsonld/tsconfig.release.json
+++ b/packages/jsonld/tsconfig.release.json
@@ -4,5 +4,5 @@
     "declarationDir": "typings"
   },
   "include": ["src"],
-  "extends": "../../tsconfig"
+  "extends": "../../tsconfig.release"
 }

--- a/packages/mnid/package.json
+++ b/packages/mnid/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "lint": "tslint",
     "test": "jest -c ../../jest.config.js",
-    "build": "tsc",
+    "build": "tsc -p tsconfig.release.json",
     "docs": "jsdoc2md --no-cache --plugin dmd-clear -t README.template --files './lib/**/*.js' > README.md"
   },
   "license": "MIT",

--- a/packages/mnid/tsconfig.release.json
+++ b/packages/mnid/tsconfig.release.json
@@ -4,5 +4,5 @@
     "declarationDir": "typings"
   },
   "include": ["src"],
-  "extends": "../../tsconfig"
+  "extends": "../../tsconfig.release"
 }

--- a/tsconfig.release.json
+++ b/tsconfig.release.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "types": ["node", "jest"],
+    "lib": ["dom", "es2015"],
+    "noImplicitThis": true,
+    "strict": true,
+    "declaration": true,
+    "sourceMap": true,
+    "moduleResolution": "node",
+    "baseUrl": "."
+  }
+}


### PR DESCRIPTION
Using the path mapping feature in the "tsconfig.json" will cause
TypeScript compiler treats these package as source files and compile
them to generate unnecessary JavaScript code.

We need the path mapping feature to run the test cases without
compiling any TypeScript source code, so split the "tsconfig.json"
for different usages.

 - "tsconfig.json": developing and testing packages (w path mapping)
 - "tsconfig.release.json": building the packages (w/o path mapping)