### PR TITLE
fix: Fix document generation workflow

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "lint": "tslint --format verbose ./packages/*/src/**/*.ts",
     "test": "jest",
     "test:coverage": "jest --verbose --coverage",
-    "docs": "yarn run build && lerna exec -- yarn run docs",
+    "docs": "lerna exec -- yarn run docs",
     "clean": "lerna exec --parallel -- rimraf lib typings",
     "build": "yarn run clean && lerna exec -- yarn run build",
     "audit": "yarn audit && lerna exec -- yarn audit"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "test": "jest -c ../../jest.config.js",
     "build": "tsc -p tsconfig.release.json",
-    "docs": "tsc && jsdoc2md --no-cache --plugin dmd-clear -t README.template --files './lib/**/*.js' > README.md"
+    "docs": "yarn run build && jsdoc2md --no-cache --plugin dmd-clear -t README.template --files './lib/**/*.js' > README.md"
   },
   "license": "MIT",
   "repository": {

--- a/packages/credential/package.json
+++ b/packages/credential/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "test": "jest -c ../../jest.config.js",
     "build": "tsc -p tsconfig.release.json",
-    "docs": "tsc && jsdoc2md --no-cache --plugin dmd-clear -t README.template --files './lib/**/*.js' > README.md"
+    "docs": "yarn run build && jsdoc2md --no-cache --plugin dmd-clear -t README.template --files './lib/**/*.js' > README.md"
   },
   "license": "MIT",
   "repository": {

--- a/packages/did/package.json
+++ b/packages/did/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "test": "jest -c ../../jest.config.js",
     "build": "tsc -p tsconfig.release.json",
-    "docs": "jsdoc2md --no-cache --plugin dmd-clear -t README.template --files './lib/**/*.js' > README.md"
+    "docs": "yarn run build && jsdoc2md --no-cache --plugin dmd-clear -t README.template --files './lib/**/*.js' > README.md"
   },
   "license": "MIT",
   "repository": {

--- a/packages/jsonld/package.json
+++ b/packages/jsonld/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "test": "jest -c ../../jest.config.js",
     "build": "tsc -p tsconfig.release.json",
-    "docs": "tsc && jsdoc2md --no-cache --plugin dmd-clear -t README.template --files './lib/**/*.js' > README.md"
+    "docs": "yarn run build && jsdoc2md --no-cache --plugin dmd-clear -t README.template --files './lib/**/*.js' > README.md"
   },
   "license": "MIT",
   "repository": {

--- a/packages/mnid/package.json
+++ b/packages/mnid/package.json
@@ -9,7 +9,7 @@
     "lint": "tslint",
     "test": "jest -c ../../jest.config.js",
     "build": "tsc -p tsconfig.release.json",
-    "docs": "jsdoc2md --no-cache --plugin dmd-clear -t README.template --files './lib/**/*.js' > README.md"
+    "docs": "yarn run build && jsdoc2md --no-cache --plugin dmd-clear -t README.template --files './lib/**/*.js' > README.md"
   },
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
The document generation workflow will compile the TypeScript to
JavaScript, then read the JSDoc from the Javascript to generate the
readme documentation.

Because we changed the split the "tsconfig.json" for different
purposes, change document generation workflow to use
"tsconfig.release.json" to compile the TypeScript.