### PR TITLE
chore(jsonld): Upgrade jsonld-signatures to v4.2.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "packages/*"
   ],
   "scripts": {
-    "init": "yarn install --ignore-engines && lerna bootstrap",
+    "init": "yarn install && lerna bootstrap",
     "lint": "tslint --format verbose ./packages/*/src/**/*.ts",
     "test": "jest",
     "test:coverage": "jest --verbose --coverage",

--- a/packages/jsonld/package.json
+++ b/packages/jsonld/package.json
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "jsonld": "^1.6.2",
-    "jsonld-signatures": "^4.2.0",
+    "jsonld-signatures": "^4.2.1",
     "node-forge": "^0.8.2"
   },
   "publishConfig": {


### PR DESCRIPTION
Since the jsonld-signatures v4.2.1 specifies the Node.js engine
properly, the project initial script can install the packages without
using the --ignore-engines flag.

See also: https://github.com/digitalbazaar/jsonld-signatures/pull/73