### PR TITLE
chore: remove devent setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,16 +35,10 @@ To register/resolve the identifier, do the following:
 import { composeAPI } from '@tangleid/core';
 
 const tid = composeAPI({
-  providers: {
-    // mainnet
-    '0x1': 'http://node.deviceproof.org:14265',
-    // devnet
-    '0x2': 'https://nodes.devnet.thetangle.org:443',
-  },
+  provider: 'https://tangle.puyuma.org',
 });
 
 const { seed, did, document } = await tid.registerIdentifier({
-  network: '0x1',
   publicKey,
 });
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -42,7 +42,7 @@ yarn add @tangleid/core
 | Param | Type | Default | Description |
 | --- | --- | --- | --- |
 | [settings] | <code>object</code> | <code>{}</code> | Connection settings |
-| [params.providers] | <code>object</code> |  | The IRI node providers in differenct network. |
+| [params.provider] | <code>object</code> |  | Uri of IRI node. |
 
 Composes API object from it's components
 

--- a/packages/core/src/composeAPI.ts
+++ b/packages/core/src/composeAPI.ts
@@ -1,5 +1,5 @@
 import { IdenityRegistry } from '@tangleid/did';
-import { IriProviders } from '../../types';
+import { IriProvider } from '../../types';
 
 import { DocumentLoader } from './jsonld/documentLoader';
 
@@ -9,7 +9,7 @@ import { createSignRsaSignature } from './createSignRsaSignature';
 import { createVerifyRsaSignature } from './createVerifyRsaSignature';
 
 export type Settings = {
-  providers?: IriProviders;
+  provider?: IriProvider;
 };
 
 /**
@@ -20,12 +20,12 @@ export type Settings = {
  * @memberof module:core
  *
  * @param {object} [settings={}] - Connection settings
- * @param {object} [params.providers] - The IRI node providers in differenct network.
+ * @param {object} [params.provider] - Uri of IRI node.
  *
  * @return {API}
  */
 export const composeAPI = (settings: Partial<Settings> = {}) => {
-  const idenityRegistry = new IdenityRegistry({ providers: settings.providers });
+  const idenityRegistry = new IdenityRegistry({ provider: settings.provider });
   const documentLoader = new DocumentLoader(idenityRegistry);
   const loader = documentLoader.loader();
 

--- a/packages/core/src/createRegisterIdentifier.ts
+++ b/packages/core/src/createRegisterIdentifier.ts
@@ -15,8 +15,8 @@ export const createRegisterIdentifier = (registry: IdenityRegistry) => {
    * @returns {Promise<object>} Promise object represents the result. The result
    *   conatains DID `did` and DID document `document`.
    */
-  return async (network: NetworkIdentifer, seed: Seed, publicKeys: PublicKeyPem[] = []) => {
-    const didDocument = await registry.publish(network, seed, publicKeys);
+  return async (seed: Seed, publicKeys: PublicKeyPem[] = []) => {
+    const didDocument = await registry.publish(seed, publicKeys);
 
     return didDocument;
   };

--- a/packages/core/test/core.test.ts
+++ b/packages/core/test/core.test.ts
@@ -20,13 +20,11 @@ jest.mock(
 describe('@tangleid/core', () => {
   it('register identifier and generate a verifiable credential', async () => {
     const tid = composeAPI({
-      providers: {
-        '0x1': 'http://node.deviceproof.org:14265',
-      },
+      provider: 'https://tangle.puyuma.org',
     });
 
     const seed = generateSeed();
-    const { document } = await tid.registerIdentifier('0x1', seed, [publicKeyPem]);
+    const { document } = await tid.registerIdentifier(seed, [publicKeyPem]);
 
     // @ts-ignore
     const publicKey = document.publicKey[0];

--- a/packages/did/README.md
+++ b/packages/did/README.md
@@ -16,15 +16,6 @@ or using [yarn](https://yarnpkg.com/):
 yarn add @tangleid/did
 ```
 
-## Network Identifiers
-
-Used to describe which Tangle network interacts.
-
-| Identitier | Network        |
-| ---------- | -------------- |
-| 0x1        | Tangle Mainnet |
-| 0x2        | Tangle Devnet  |
-
 ## API Reference
 
 

--- a/packages/did/README.template
+++ b/packages/did/README.template
@@ -16,15 +16,6 @@ or using [yarn](https://yarnpkg.com/):
 yarn add @tangleid/did
 ```
 
-## Network Identifiers
-
-Used to describe which Tangle network interacts.
-
-| Identitier | Network        |
-| ---------- | -------------- |
-| 0x1        | Tangle Mainnet |
-| 0x2        | Tangle Devnet  |
-
 ## API Reference
 
 {{#module name="did"~}}

--- a/packages/did/src/IdenityRegistry.ts
+++ b/packages/did/src/IdenityRegistry.ts
@@ -8,18 +8,15 @@ import {
   Seed,
   Did,
   DidDocument,
-  IriProviders,
+  IriProvider,
   NetworkIdentifer,
   PublicKeyPem,
 } from '../../types';
 
-const DEFAULT_PROVIDERS: IriProviders = {
-  '0x1': 'https://nodes.thetangle.org:443',
-  '0x2': 'https://nodes.devnet.thetangle.org:443',
-};
+const DEFAULT_PROVIDER: IriProvider = 'https://tangle.puyuma.org';
 
 type IdenityRegistryParams = {
-  providers?: IriProviders;
+  provider?: IriProvider;
 };
 
 /**
@@ -28,23 +25,18 @@ type IdenityRegistryParams = {
  * and uses the profile channel to save the corresponding DID document.
  */
 export class IdenityRegistry {
-  providers: IriProviders;
+  provider: IriProvider;
 
   /**
    * @constructor
-   * @param {object} [params.providers = DEFAULT_PROVIDERS] - The IRI node providers in differenct network.
+   * @param {object} [params.provider = DEFAULT_PROVIDER] - Uri of IRI node.
    */
   constructor(params: IdenityRegistryParams = {}) {
-    this.providers = params.providers || DEFAULT_PROVIDERS;
-  }
-
-  getProvider = (network: NetworkIdentifer) => {
-    return this.providers[network];
+    this.provider = params.provider || DEFAULT_PROVIDER;
   }
 
   getIota = (network: NetworkIdentifer) => {
-    const provider = this.getProvider(network);
-    mamClient.setProvider(provider);
+    mamClient.setProvider(this.provider);
     const iota = mamClient.getIota();
 
     return iota;
@@ -62,17 +54,16 @@ export class IdenityRegistry {
 
   /**
    * Publish the DID document to the Tangle MAM channel with specific network.
-   * @param {string} network - The network identitfer.
    * @param {string} seed - The seed of the MAM channel.
    * @param {string[]} publicKeys - PEM-formatted public Keys.
    * @returns {Promise} Promise object represents the result. The result
    *   conatains DID `did` and DID document `document`.
    */
   publish = async (
-    network: NetworkIdentifer,
     seed: Seed,
     publicKeys: PublicKeyPem[] = [],
   ) => {
+    const network = '0x1';
     const ticClient = await this.getTicClient(network, seed);
     const did = encodeToDid({ network, address: ticClient.masterRoot });
     const document: DidDocument = {

--- a/packages/did/test/registry.test.ts
+++ b/packages/did/test/registry.test.ts
@@ -30,7 +30,7 @@ beforeAll(async () => {
   publicKeys = [keypair.publicKey];
 
   const registry = new IdenityRegistry();
-  const result = await registry.publish('0x1', mamClient.generateSeed(), publicKeys);
+  const result = await registry.publish(mamClient.generateSeed(), publicKeys);
   did = result.did;
   document = result.document;
   resolved = await registry.fetch(did);

--- a/packages/types.ts
+++ b/packages/types.ts
@@ -17,9 +17,7 @@ export type MnidModel = {
   address: Address;
 };
 
-export type IriProviders = {
-  [index: string]: string;
-};
+export type IriProvider = string;
 
 /* Crypto */
 export type RsaKeyPair = {


### PR DESCRIPTION
Since we do not recommend to register identifier with Tangle Devnet,
remove the network identifier setting and force the MNID to encode the
id-string with main-net.