### PR TITLE
refactor: rename IriProvider to TangleProvider

### DIFF
--- a/packages/core/src/CoreAPI.ts
+++ b/packages/core/src/CoreAPI.ts
@@ -2,10 +2,10 @@ import { IdenityRegistry } from '@tangleid/did';
 import { signRsaSignature, verifyRsaSignature } from '@tangleid/jsonld';
 import { DocumentLoader } from './jsonld/documentLoader';
 
-import { IriProvider, Seed, Did, PublicKeyMeta, PrivateKeyPem, PublicKeyPem } from '../../types';
+import { TangleProvider, Seed, Did, PublicKeyMeta, PrivateKeyPem, PublicKeyPem } from '../../types';
 
 export type Settings = {
-  provider?: IriProvider;
+  provider?: TangleProvider;
 };
 
 export class CoreAPI {

--- a/packages/did/src/IdenityRegistry.ts
+++ b/packages/did/src/IdenityRegistry.ts
@@ -8,15 +8,15 @@ import {
   Seed,
   Did,
   DidDocument,
-  IriProvider,
+  TangleProvider,
   NetworkIdentifer,
   PublicKeyPem,
 } from '../../types';
 
-const DEFAULT_PROVIDER: IriProvider = 'https://tangle.puyuma.org';
+const DEFAULT_PROVIDER: TangleProvider = 'https://tangle.puyuma.org';
 
 type IdenityRegistryParams = {
-  provider?: IriProvider;
+  provider?: TangleProvider;
 };
 
 /**
@@ -25,7 +25,7 @@ type IdenityRegistryParams = {
  * and uses the profile channel to save the corresponding DID document.
  */
 export class IdenityRegistry {
-  provider: IriProvider;
+  provider: TangleProvider;
 
   /**
    * @constructor

--- a/packages/types.ts
+++ b/packages/types.ts
@@ -17,7 +17,7 @@ export type MnidModel = {
   address: Address;
 };
 
-export type IriProvider = string;
+export type TangleProvider = string;
 
 /* Crypto */
 export type RsaKeyPair = {


### PR DESCRIPTION
To avoid the type definition name misleading, rename the IriProvider
to TangleProvider.