### PR TITLE
feature: simplify identifier registration

### DIFF
--- a/packages/core/src/CoreAPI.ts
+++ b/packages/core/src/CoreAPI.ts
@@ -13,7 +13,7 @@ export class CoreAPI {
   private documentLoader: DocumentLoader;
 
   constructor(settings: Partial<Settings> = {}) {
-    this.registry = new IdenityRegistry({ provider: settings.provider });
+    this.registry = new IdenityRegistry(settings.provider);
     this.documentLoader = new DocumentLoader(this.registry);
   }
 

--- a/packages/did/package.json
+++ b/packages/did/package.json
@@ -16,11 +16,9 @@
     "url": "https://github.com/TangleID/TangleID"
   },
   "dependencies": {
-    "@tangleid/mnid": "^1.2.0",
-    "mam.client.js": "git+https://git@github.com/iotaledger/mam.client.js.git",
+    "@iota/converter": "1.0.0-beta.21",
     "mam.tools.js": "git+https://github.com/TangleID/mam.tools.js.git#develop",
-    "node-forge": "^0.8.2",
-    "tic.api.js": "git+https://github.com/TangleID/tic.api.js.git#develop"
+    "node-forge": "^0.8.2"
   },
   "publishConfig": {
     "access": "public"

--- a/yarn.lock
+++ b/yarn.lock
@@ -680,112 +680,115 @@
     exec-sh "^0.3.2"
     minimist "^1.2.0"
 
-"@iota/bundle-validator@^1.0.0-beta.12":
-  version "1.0.0-beta.12"
-  resolved "https://registry.yarnpkg.com/@iota/bundle-validator/-/bundle-validator-1.0.0-beta.12.tgz#f3d2de3b7907f83dba5fd3db884f534e9a3b59fc"
-  integrity sha512-Kd48tjQ2UlFTAIkP+u6G0tVwM5RFjdGjx7Fvu3PwC9eINVJHYGEb4sX7N85PIkIwowwZfN5mcmzL3G6dkGJmoA==
+"@iota/bundle-validator@^1.0.0-beta.21":
+  version "1.0.0-beta.21"
+  resolved "https://registry.yarnpkg.com/@iota/bundle-validator/-/bundle-validator-1.0.0-beta.21.tgz#3e55ff92446c3337c32bb693b7b694f08a3dc6f6"
+  integrity sha512-MB/AwpXncNtT63BJiMu3kXzG5vObv1eF8LTI8AeWc0Wpx96tymPz9jz+4pPK6ku9gEULnqpxvK7eAvg48MFHlg==
   dependencies:
-    "@iota/converter" "^1.0.0-beta.12"
-    "@iota/kerl" "^1.0.0-beta.12"
-    "@iota/signing" "^1.0.0-beta.12"
-    "@iota/transaction" "^1.0.0-beta.12"
-    "@iota/transaction-converter" "^1.0.0-beta.12"
+    "@iota/converter" "^1.0.0-beta.21"
+    "@iota/kerl" "^1.0.0-beta.21"
+    "@iota/signing" "^1.0.0-beta.21"
+    "@iota/transaction" "^1.0.0-beta.21"
+    "@iota/transaction-converter" "^1.0.0-beta.21"
 
-"@iota/bundle@^1.0.0-beta.12":
-  version "1.0.0-beta.12"
-  resolved "https://registry.yarnpkg.com/@iota/bundle/-/bundle-1.0.0-beta.12.tgz#ba6e3f87f933a207b10459d11fa63dd444490989"
-  integrity sha512-Eb18nWzhXB4chq6Nuaz23xP72F65MlDKpgt6KiZ5Lhkfn6P19UYjfC4FXY3K0Cigij2fC1cX+tdefQprCW/TEw==
+"@iota/bundle@^1.0.0-beta.21":
+  version "1.0.0-beta.21"
+  resolved "https://registry.yarnpkg.com/@iota/bundle/-/bundle-1.0.0-beta.21.tgz#41d6b410b5dd987a58409fcf6078ac323cc9bf57"
+  integrity sha512-3P5xGXDiB/1U59Fl5Mm+tM9lEll43cdgChp7ry/Wca0igfRW20UOpkla+f/ppnbnGeNQkDV7bdvhFxmr2OjuBQ==
   dependencies:
-    "@iota/converter" "^1.0.0-beta.12"
-    "@iota/kerl" "^1.0.0-beta.12"
-    "@iota/signing" "^1.0.0-beta.12"
-    "@iota/transaction" "^1.0.0-beta.12"
+    "@iota/converter" "^1.0.0-beta.21"
+    "@iota/kerl" "^1.0.0-beta.21"
+    "@iota/signing" "^1.0.0-beta.21"
+    "@iota/transaction" "^1.0.0-beta.21"
     "@types/warning" "^3.0.0"
     warning "^4.0.3"
 
-"@iota/checksum@^1.0.0-beta.12":
-  version "1.0.0-beta.12"
-  resolved "https://registry.yarnpkg.com/@iota/checksum/-/checksum-1.0.0-beta.12.tgz#cdc82394099f7a7b154cf19207f31631a9228c0a"
-  integrity sha512-K2Q3bw4P7HJkPxeNjpulCsq/d3c9w2g+wbwYJxi51a18pnlPpd5AyBam9xfNXo8m/S47mmPuctraexgm+Q0Y1A==
+"@iota/checksum@^1.0.0-beta.21":
+  version "1.0.0-beta.21"
+  resolved "https://registry.yarnpkg.com/@iota/checksum/-/checksum-1.0.0-beta.21.tgz#7ba1fba95affa73a3a44ac9455a22b59961762f5"
+  integrity sha512-v5JUJrta3DQxCj246mgg80QZZvw1p457t4WM9Do8zObiyKRaF6gXTasNW9L8LPXcCiXBGSUQchyvvQ0x28tPow==
   dependencies:
-    "@iota/converter" "^1.0.0-beta.12"
-    "@iota/kerl" "^1.0.0-beta.12"
+    "@iota/converter" "^1.0.0-beta.21"
+    "@iota/kerl" "^1.0.0-beta.21"
 
-"@iota/converter@^1.0.0-beta.11", "@iota/converter@^1.0.0-beta.12":
-  version "1.0.0-beta.12"
-  resolved "https://registry.yarnpkg.com/@iota/converter/-/converter-1.0.0-beta.12.tgz#873dfacbef2ac18aec814100c10f50568d54ef51"
-  integrity sha512-h12Wk72/lCMHOFLE7B6TctMizhGcDQspaYIZlqwQTdij3mPynfTrlyAIJhJw26cf3sNER9sOwR6FgVgSpVYUnQ==
-
-"@iota/core@^1.0.0-beta.11":
-  version "1.0.0-beta.12"
-  resolved "https://registry.yarnpkg.com/@iota/core/-/core-1.0.0-beta.12.tgz#c7d9a1aca0363cb2f95ea9fb484f991ca5d1cf36"
-  integrity sha512-OFJu0SaYrQP+PCFNWx9pvqL6jQwN+DIMt2h5vcEOSlJVIBDyEfDOOiFuMkBgTB7+jF9hDWpg1mtkTrEl9FmLKQ==
+"@iota/converter@1.0.0-beta.21", "@iota/converter@^1.0.0-beta.12", "@iota/converter@^1.0.0-beta.21":
+  version "1.0.0-beta.21"
+  resolved "https://registry.yarnpkg.com/@iota/converter/-/converter-1.0.0-beta.21.tgz#ea94bb738cf1df753530e60a2089ee187622fae2"
+  integrity sha512-voiOZyaCCCTQ0rAwkwkuMAhuz4yLanPVd1nmZe0Jh1OeksQWZzlnJL7QQcBP4k4LZvRKw0sb1FyIKIsDJfdyig==
   dependencies:
-    "@iota/bundle" "^1.0.0-beta.12"
-    "@iota/bundle-validator" "^1.0.0-beta.12"
-    "@iota/checksum" "^1.0.0-beta.12"
-    "@iota/converter" "^1.0.0-beta.12"
-    "@iota/curl" "^1.0.0-beta.12"
-    "@iota/http-client" "^1.0.0-beta.12"
-    "@iota/kerl" "^1.0.0-beta.12"
-    "@iota/pad" "^1.0.0-beta.12"
-    "@iota/signing" "^1.0.0-beta.12"
-    "@iota/transaction" "^1.0.0-beta.12"
-    "@iota/transaction-converter" "^1.0.0-beta.12"
-    bluebird "^3.5.1"
+    core-js "^3.1.4"
 
-"@iota/curl@^1.0.0-beta.11", "@iota/curl@^1.0.0-beta.12":
-  version "1.0.0-beta.12"
-  resolved "https://registry.yarnpkg.com/@iota/curl/-/curl-1.0.0-beta.12.tgz#50a9b6b4df513dd9f6ea02d98bf561d0a5817f65"
-  integrity sha512-2O6CSBxo+GesW8V4MQobMzIzhmYmPOdhHTcB81cfb4iAXMXY3WlN1IdOjIWzCEkDAUdUX5cpfyjpYDasjxQELg==
+"@iota/core@^1.0.0-beta.12":
+  version "1.0.0-beta.21"
+  resolved "https://registry.yarnpkg.com/@iota/core/-/core-1.0.0-beta.21.tgz#18c6ab679ba3bcc8a93435debcc1cdba27fcf1fb"
+  integrity sha512-3RS6Sf4w3qbo+F6BeiLCEJ/LIC+CVw7cJePdUPTqdu1VezPOXwdxk5UWP7rYd1uei7vGYAJ9GWh2UJbrqNYsqA==
+  dependencies:
+    "@iota/bundle" "^1.0.0-beta.21"
+    "@iota/bundle-validator" "^1.0.0-beta.21"
+    "@iota/checksum" "^1.0.0-beta.21"
+    "@iota/converter" "^1.0.0-beta.21"
+    "@iota/curl" "^1.0.0-beta.19"
+    "@iota/http-client" "^1.0.0-beta.21"
+    "@iota/kerl" "^1.0.0-beta.21"
+    "@iota/pad" "^1.0.0-beta.19"
+    "@iota/signing" "^1.0.0-beta.21"
+    "@iota/transaction" "^1.0.0-beta.21"
+    "@iota/transaction-converter" "^1.0.0-beta.21"
+    bluebird "^3.5.5"
 
-"@iota/http-client@^1.0.0-beta.12":
-  version "1.0.0-beta.12"
-  resolved "https://registry.yarnpkg.com/@iota/http-client/-/http-client-1.0.0-beta.12.tgz#2b9e8d0b3c3799578d0a869c22274d3eca573b37"
-  integrity sha512-FBA23HqMFe/OSim+ouEkVNCPoVIb9sLt2ZtuzvICrrhHYIPiHyZC6QR1cBEmZuQjaY9fXzuBbH20CMpOhL+mtA==
+"@iota/curl@^1.0.0-beta.12", "@iota/curl@^1.0.0-beta.19":
+  version "1.0.0-beta.19"
+  resolved "https://registry.yarnpkg.com/@iota/curl/-/curl-1.0.0-beta.19.tgz#7c30bec4c7225eaf1a691802251c9199177a54a8"
+  integrity sha512-bUr6VW8lP1XYhAkzUacc8U28qO2Ibdl6R5CSF7N34GgjO2sEkn4DnlzL1VU8cCv+8rfBlZ9qIvYGzklic49JJw==
+
+"@iota/http-client@^1.0.0-beta.21":
+  version "1.0.0-beta.21"
+  resolved "https://registry.yarnpkg.com/@iota/http-client/-/http-client-1.0.0-beta.21.tgz#0a0fc5962b16818e872abad8af060bf8ee5b342d"
+  integrity sha512-5T0qQNrEYjU9IZuiBbmdsF7MeAgu0WXO5KRufKIZyk+sfzZ3PETZJgq5BrHOBFAzgdakmMOGVS73OPrkvKGmyA==
   dependencies:
     cross-fetch "^3.0.0"
+    url-parse "^1.4.7"
 
-"@iota/kerl@^1.0.0-beta.12":
-  version "1.0.0-beta.12"
-  resolved "https://registry.yarnpkg.com/@iota/kerl/-/kerl-1.0.0-beta.12.tgz#14eeb6f04b9f7fc025c23059e9d3473a7c5ed84e"
-  integrity sha512-Af/MxEBvKfkSkrjr87pl4y6qBvHzMGZWTsddBLP3iYJXY+6NW9kHKzO0UEwS/07eiS1y3bKsjP+WFgrnHN8f6Q==
+"@iota/kerl@^1.0.0-beta.21":
+  version "1.0.0-beta.21"
+  resolved "https://registry.yarnpkg.com/@iota/kerl/-/kerl-1.0.0-beta.21.tgz#8e8760056af469af5fc4239411d270ae7187a10d"
+  integrity sha512-JzarmedEpLvs8ZlA37FqaOcU6rJIiSJbEjkJMZiDm3ZWcAgqcnzfEqyT3RDn2capPsQ3maiVgL60oFueizMbNQ==
   dependencies:
     "@types/crypto-js" "^3.1.38"
     crypto-js "^3.1.9-1"
 
-"@iota/pad@^1.0.0-beta.12":
-  version "1.0.0-beta.12"
-  resolved "https://registry.yarnpkg.com/@iota/pad/-/pad-1.0.0-beta.12.tgz#94893c932604c0d8f90e77ce2e00a43affec1274"
-  integrity sha512-7WdywCvv65kpSrfvAAmof+Q4Qp2hYYazwwdcox7cdEdp5GV2boqzoLogj8z1yWGKSLNjoWGtG3Ii7E94zBRaIQ==
+"@iota/pad@^1.0.0-beta.19":
+  version "1.0.0-beta.19"
+  resolved "https://registry.yarnpkg.com/@iota/pad/-/pad-1.0.0-beta.19.tgz#ffe39ebf149bf310222680bafbca68c536758d16"
+  integrity sha512-J82UxKK3d5x6bxDKzi3qgRpy/NxCXbuDprC3ar225ahwtt1Qd0srQY3ZN6GjCAtV9/bFe7EysXqGcQnumfECBQ==
 
-"@iota/signing@^1.0.0-beta.12":
-  version "1.0.0-beta.12"
-  resolved "https://registry.yarnpkg.com/@iota/signing/-/signing-1.0.0-beta.12.tgz#d75357b02029731342689e901a95c31e3a406d5d"
-  integrity sha512-PnT6gkTZQA7T7FuW4+SoUZuCoCTxRq8TRocaooe1JUu2Mj8xtQ/uJqRcWsxMo1qjFS6qkv6ZudJSyfvJfBKhmQ==
+"@iota/signing@^1.0.0-beta.21":
+  version "1.0.0-beta.21"
+  resolved "https://registry.yarnpkg.com/@iota/signing/-/signing-1.0.0-beta.21.tgz#88d587dd48853235a5ebb6c2edeb181ea890c1c9"
+  integrity sha512-LATQAcXYoOzPGg3NlrSU6taKkM3PJgc/fkzxh8sPjWGXvOnFzODiU3Y3Gq3pjjGvZTAYx6KQfUVJSBjea8wXLw==
   dependencies:
-    "@iota/converter" "^1.0.0-beta.12"
-    "@iota/kerl" "^1.0.0-beta.12"
-    "@iota/pad" "^1.0.0-beta.12"
+    "@iota/converter" "^1.0.0-beta.21"
+    "@iota/kerl" "^1.0.0-beta.21"
+    "@iota/pad" "^1.0.0-beta.19"
 
-"@iota/transaction-converter@^1.0.0-beta.12":
-  version "1.0.0-beta.12"
-  resolved "https://registry.yarnpkg.com/@iota/transaction-converter/-/transaction-converter-1.0.0-beta.12.tgz#a977c93d5f0db2b78346550c843d91bbeee8463b"
-  integrity sha512-ePkcOmHuzyGwYmYa8+y6ro9sWS1ZRWtiu05odcEavE8vHgWNdHE9N1EaFH1yjjBltYmdZBlP2RFkoH/Hcl2YRQ==
+"@iota/transaction-converter@^1.0.0-beta.21":
+  version "1.0.0-beta.21"
+  resolved "https://registry.yarnpkg.com/@iota/transaction-converter/-/transaction-converter-1.0.0-beta.21.tgz#e922cf83cc2028b7a5bc0626c86981bd76ee0a21"
+  integrity sha512-Q0d9Wq9gm2u+QpTgGpfrjFGkA4rm1XxVm8HCV61DqHuSYxPWL8tSAyKlo6hQH50LQi4UPSiEVq/VPLSZpRYaIQ==
   dependencies:
-    "@iota/converter" "^1.0.0-beta.12"
-    "@iota/pad" "^1.0.0-beta.12"
-    "@iota/transaction" "^1.0.0-beta.12"
+    "@iota/converter" "^1.0.0-beta.21"
+    "@iota/pad" "^1.0.0-beta.19"
+    "@iota/transaction" "^1.0.0-beta.21"
 
-"@iota/transaction@^1.0.0-beta.12":
-  version "1.0.0-beta.12"
-  resolved "https://registry.yarnpkg.com/@iota/transaction/-/transaction-1.0.0-beta.12.tgz#85039d3439f44417d9cec6ea6a361107c3397564"
-  integrity sha512-l+zvo6gJUOk8t6L9HSsYNbeU5mOovR97BwGmhgVrPBs3Qfv58iSsEBrgpHkjJEvTd3GvLYl7V3FiLWpa1Hdcbw==
+"@iota/transaction@^1.0.0-beta.21":
+  version "1.0.0-beta.21"
+  resolved "https://registry.yarnpkg.com/@iota/transaction/-/transaction-1.0.0-beta.21.tgz#09e316f94df098c7466cac6a7c34541db46942fc"
+  integrity sha512-dtVjDMq8N0l6fVjgyMrkVkhg376Ce1ONG6oBREPE37/l3aWpPbf8z3lAgagCpGyDbfN1TXITllsU1tqXZb25vA==
   dependencies:
-    "@iota/converter" "^1.0.0-beta.12"
-    "@iota/curl" "^1.0.0-beta.12"
-    "@iota/kerl" "^1.0.0-beta.12"
-    "@iota/signing" "^1.0.0-beta.12"
+    "@iota/converter" "^1.0.0-beta.21"
+    "@iota/curl" "^1.0.0-beta.19"
+    "@iota/kerl" "^1.0.0-beta.21"
+    "@iota/signing" "^1.0.0-beta.21"
     "@types/warning" "^3.0.0"
     warning "^4.0.3"
 
@@ -1966,7 +1969,14 @@ async-limiter@~1.0.0:
   resolved "https://registry.yarnpkg.com/async-limiter/-/async-limiter-1.0.0.tgz#78faed8c3d074ab81f22b4e985d79e8738f720f8"
   integrity sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg==
 
-async@^2.5.0, async@^2.6.1:
+async@^2.5.0:
+  version "2.6.3"
+  resolved "https://registry.yarnpkg.com/async/-/async-2.6.3.tgz#d72625e2344a3656e3a3ad4fa749fa83299d82ff"
+  integrity sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==
+  dependencies:
+    lodash "^4.17.14"
+
+async@^2.6.1:
   version "2.6.2"
   resolved "https://registry.yarnpkg.com/async/-/async-2.6.2.tgz#18330ea7e6e313887f5d2f2a904bac6fe4dd5381"
   integrity sha512-H1qVYh1MYhEEFLsP97cVKqCGo7KfCyTt6uEWqsTBr9SO84oK9Uwbyd/yCW+6rKJLHksBNUVWZDAjfS+Ccx0Bbg==
@@ -2081,10 +2091,10 @@ base64-js@^1.0.2:
   resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.3.0.tgz#cab1e6118f051095e58b5281aea8c1cd22bfc0e3"
   integrity sha512-ccav/yGvoa80BQDljCxsmmQ3Xvx60/UpBIij5QN21W3wBi/hhIC9OoO+KLpu9IJTS9j4DRVJ3aDDF9cMSoa2lw==
 
-base64url-universal@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/base64url-universal/-/base64url-universal-1.0.0.tgz#827f28d5c5a2b6b12eba745999e9be69099991f5"
-  integrity sha512-MxtKr4XlDeuOzSRceUAT2otQy3VSVZZ02qfM+8fWCR/nY+l2XjZ/rh/Rw+gSsLvqTKXR/u8dzGHjSUdwS6zhAA==
+base64url-universal@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/base64url-universal/-/base64url-universal-1.0.1.tgz#ea9245c9b69772395d1e2b4fcb5ca7727d1d25d1"
+  integrity sha512-9WC6S+Q/9wEPrKOn02R3VbvAtCO632EBydD34r0O+AvLhfVyuniTIiUZpB/GLLBfdv7xzH+lG7nmJH7Jtg0mnw==
   dependencies:
     base64url "^3.0.0"
 
@@ -2169,6 +2179,11 @@ bluebird@^3.5.1, bluebird@^3.5.3, bluebird@~3.5.0:
   version "3.5.4"
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.5.4.tgz#d6cc661595de30d5b3af5fcedd3c0b3ef6ec5714"
   integrity sha512-FG+nFEZChJrbQ9tIccIfZJBz3J7mLrAhxakAbnrJWn8d7aKOC+LWifa0G+p4ZqKp4y13T7juYvdhq9NzKdsrjw==
+
+bluebird@^3.5.5:
+  version "3.5.5"
+  resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.5.5.tgz#a8d0afd73251effbbd5fe384a77d73003c17a71f"
+  integrity sha512-5am6HnnfN+urzt4yfg7IgTbotDjIT/u8AJpEt0sIU9FtXfVeezXAPKswrG+xKUCOYAINpSdgZVDU6QFh+cuH3w==
 
 bn.js@=2.0.4:
   version "2.0.4"
@@ -2621,9 +2636,9 @@ colors@^1.2.1:
   integrity sha512-mmGt/1pZqYRjMxB1axhTo16/snVZ5krrKkcmMeVKxzECMMXoCgnvTPp10QgHfcbQZw8Dq2jMNG6je4JlWU0gWg==
 
 colorspace@1.1.x:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/colorspace/-/colorspace-1.1.1.tgz#9ac2491e1bc6f8fb690e2176814f8d091636d972"
-  integrity sha512-pI3btWyiuz7Ken0BWh9Elzsmv2bM9AhA7psXib4anUXy/orfZ/E0MbQwhSOG/9L8hLlalqrU0UhOuqxW1YjmVw==
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/colorspace/-/colorspace-1.1.2.tgz#e0128950d082b86a2168580796a0aa5d6c68d8c5"
+  integrity sha512-vt+OoIP2d76xLhjwbBaucYlNSpPsrJWPlBTtwCpQKIu6/CSMutyzX93O/Do0qzpH3YoHEes8YEFXyZ797rEhzQ==
   dependencies:
     color "3.0.x"
     text-hex "1.0.x"
@@ -2905,6 +2920,11 @@ core-js@3.0.1:
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.0.1.tgz#1343182634298f7f38622f95e73f54e48ddf4738"
   integrity sha512-sco40rF+2KlE0ROMvydjkrVMMG1vYilP2ALoRXcYR4obqbYIuV3Bg+51GEDW+HF8n7NRA+iaA4qD0nD9lo9mew==
 
+core-js@^3.1.4:
+  version "3.1.4"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.1.4.tgz#3a2837fc48e582e1ae25907afcd6cf03b0cc7a07"
+  integrity sha512-YNZN8lt82XIMLnLirj9MhKDFZHalwzzrL9YLt6eb0T5D0EDl4IQ90IGkua8mHbnxNrkj1d8hbdizMc0Qmg1WnQ==
+
 core-util-is@1.0.2, core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
@@ -2921,11 +2941,11 @@ cosmiconfig@^5.0.2, cosmiconfig@^5.0.7, cosmiconfig@^5.1.0:
     parse-json "^4.0.0"
 
 cross-fetch@^3.0.0:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-3.0.2.tgz#b7136491967031949c7f86b15903aef4fa3f1768"
-  integrity sha512-a4Z0EJ5Nck6QtMy9ZqloLfpvu2uMV3sBfMCR+CgSBCZc6z5KR4bfEiD3dkepH8iZgJMXQpTqf8FjMmvu/GMFkg==
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-3.0.4.tgz#7bef7020207e684a7638ef5f2f698e24d9eb283c"
+  integrity sha512-MSHgpjQqgbT/94D4CyADeNoYh52zMkCX4pcJvPP5WqPsLFMKjr2TCMg381ox5qI0ii2dPwaLx/00477knXqXVw==
   dependencies:
-    node-fetch "2.3.0"
+    node-fetch "2.6.0"
     whatwg-fetch "3.0.0"
 
 cross-spawn@^5.0.1:
@@ -2953,12 +2973,12 @@ crypto-js@^3.1.9-1:
   resolved "https://registry.yarnpkg.com/crypto-js/-/crypto-js-3.1.9-1.tgz#fda19e761fc077e01ffbfdc6e9fdfc59e8806cd8"
   integrity sha1-/aGedh/Ad+Af+/3G6f38WeiAbNg=
 
-crypto-ld@^3.5.2:
-  version "3.5.2"
-  resolved "https://registry.yarnpkg.com/crypto-ld/-/crypto-ld-3.5.2.tgz#4abe86891f2ccfe426e1b1f9d9e5bc5660bd9946"
-  integrity sha512-iW1hNxG86hbLZQQ3ENQvhJoeN66qOvvgfP/TYCYjq6Ag+6nrg/uUXWI2lkmr6+ne/Fk69fLfTB6G1LKY2WiIjg==
+crypto-ld@^3.5.3:
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/crypto-ld/-/crypto-ld-3.6.0.tgz#6e2567ea0603a0280223857e2a7a59ad01fadd56"
+  integrity sha512-+y63ZslWXsSnCRo+XCE3O+sEIQy4Wn8BuqXV1Feesl612oCqpDRzu2DFwKyOFbKp/egW0ZZxyZHL3epZxAL+Jw==
   dependencies:
-    base64url-universal "^1.0.0"
+    base64url-universal "^1.0.1"
     bs58 "^4.0.1"
     node-forge "^0.8.0"
     sodium-native "^2.3.0"
@@ -3503,7 +3523,7 @@ extend-shallow@^3.0.0, extend-shallow@^3.0.2:
     assign-symbols "^1.0.0"
     is-extendable "^1.0.1"
 
-extend@^3.0.1, extend@~3.0.2:
+extend@~3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.2.tgz#f8b1136b4071fbd8eb140aff858b1019ec2915fa"
   integrity sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==
@@ -5191,15 +5211,15 @@ jsonfile@^4.0.0:
   optionalDependencies:
     graceful-fs "^4.1.6"
 
-jsonld-signatures@^4.2.0:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/jsonld-signatures/-/jsonld-signatures-4.2.0.tgz#ed4286d8a92093bc8fb0478cb89775f6a2d2ffbf"
-  integrity sha512-JKw5KS6DyjntdPFM43y9ygp3jrsft6LcKLca1I1EpWJbf2wR6KDlSTWCn0nUiJioJUD0vvdA8qsxOdNqMgVEtA==
+jsonld-signatures@^4.2.1:
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/jsonld-signatures/-/jsonld-signatures-4.2.1.tgz#6cb43fcfdd82473fd628f028771585160393fd6b"
+  integrity sha512-sAxJaTA1s9LBuA/Sv0qyK784733ARZ0k3O6k6StsczmBKv666Cla6yNQmyZuyGBokU+WVqPFK48btpPRkJbpbQ==
   dependencies:
     base64url "^3.0.1"
     bitcore-message "github:CoMakery/bitcore-message#dist"
     bs58 "^4.0.1"
-    crypto-ld "^3.5.2"
+    crypto-ld "^3.5.3"
     jsonld "^1.6.2"
     node-forge "^0.8.3"
     security-context "^3.0.1"
@@ -5545,6 +5565,11 @@ lodash@^4.17.11, lodash@^4.17.5, lodash@^4.2.1:
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
   integrity sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==
 
+lodash@^4.17.14:
+  version "4.17.15"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
+  integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
+
 log-symbols@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/log-symbols/-/log-symbols-1.0.2.tgz#376ff7b58ea3086a0f09facc74617eca501e1a18"
@@ -5651,24 +5676,12 @@ makeerror@1.0.x:
     tmpl "1.0.x"
 
 "mam.client.js@git+https://git@github.com/iotaledger/mam.client.js.git":
-  version "0.7.2"
-  resolved "git+https://git@github.com/iotaledger/mam.client.js.git#882fe33405c2efd42033d435801542b45b77fd69"
+  version "0.7.3"
+  resolved "git+https://git@github.com/iotaledger/mam.client.js.git#fb520cc6449f4c35e26d8b0961ee0b8fb8e2d25c"
   dependencies:
-    "@iota/converter" "^1.0.0-beta.11"
-    "@iota/core" "^1.0.0-beta.11"
-    "@iota/curl" "^1.0.0-beta.11"
-
-"mam.tools.js@git+https://git@github.com/TangleID/mam.tools.js.git#develop":
-  version "0.5.1"
-  uid "04dedce992cb96f33649b8968e6f2ddb2eb659b4"
-  resolved "git+https://git@github.com/TangleID/mam.tools.js.git#04dedce992cb96f33649b8968e6f2ddb2eb659b4"
-  dependencies:
-    debug "^3.1.0"
-    iota.lib.js "^0.4.7"
-    mam.client.js "git+https://git@github.com/iotaledger/mam.client.js.git"
-    minimist "^1.2.0"
-    supports-color "^5.4.0"
-    winston "^3.0.0"
+    "@iota/converter" "^1.0.0-beta.12"
+    "@iota/core" "^1.0.0-beta.12"
+    "@iota/curl" "^1.0.0-beta.12"
 
 "mam.tools.js@git+https://github.com/TangleID/mam.tools.js.git#develop":
   version "0.5.1"
@@ -5996,7 +6009,12 @@ node-fetch-npm@^2.0.2:
     json-parse-better-errors "^1.0.0"
     safe-buffer "^5.1.1"
 
-node-fetch@2.3.0, node-fetch@^2.3.0:
+node-fetch@2.6.0:
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.0.tgz#e633456386d4aa55863f676a7ab0daa8fdecb0fd"
+  integrity sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA==
+
+node-fetch@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.3.0.tgz#1a1d940bbfb916a1d3e0219f037e89e71f8c5fa5"
   integrity sha512-MOd8pV3fxENbryESLgVIeaGKrdl+uaYhCSSVkjeOb/31/njTpcis5aWfdqgNlHIrKOLRbMnfPINPOML2CIFeXA==
@@ -6840,6 +6858,11 @@ qs@~6.5.2:
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.2.tgz#cb3ae806e8740444584ef154ce8ee98d403f3e36"
   integrity sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==
 
+querystringify@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/querystringify/-/querystringify-2.1.1.tgz#60e5a5fd64a7f8bfa4d2ab2ed6fdf4c85bad154e"
+  integrity sha512-w7fLxIRCRT7U8Qu53jQnJyPkYZIaR4n5151KMfcJlO/A9397Wxb1amJvROTK6TOnp7PfoAmg/qXiNHI+08jRfA==
+
 quick-lru@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/quick-lru/-/quick-lru-1.1.0.tgz#4360b17c61136ad38078397ff11416e186dcfbb8"
@@ -6969,10 +6992,19 @@ read@1, read@~1.0.1:
     string_decoder "~1.1.1"
     util-deprecate "~1.0.1"
 
-"readable-stream@2 || 3", readable-stream@^3.0.2, readable-stream@^3.1.1:
+"readable-stream@2 || 3", readable-stream@^3.0.2:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-3.3.0.tgz#cb8011aad002eb717bf040291feba8569c986fb9"
   integrity sha512-EsI+s3k3XsW+fU8fQACLN59ky34AZ14LoeVZpYwmZvldCFo0r0gnelwF2TcMjLor/BTL5aDJVBMkss0dthToPw==
+  dependencies:
+    inherits "^2.0.3"
+    string_decoder "^1.1.1"
+    util-deprecate "^1.0.1"
+
+readable-stream@^3.1.1:
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-3.4.0.tgz#a51c26754658e0a3c21dbf59163bd45ba6f447fc"
+  integrity sha512-jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==
   dependencies:
     inherits "^2.0.3"
     string_decoder "^1.1.1"
@@ -7178,6 +7210,11 @@ require-main-filename@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/require-main-filename/-/require-main-filename-1.0.1.tgz#97f717b69d48784f5f526a6c5aa8ffdda055a4d1"
   integrity sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=
+
+requires-port@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/requires-port/-/requires-port-1.0.0.tgz#925d2601d39ac485e091cf0da5c6e694dc3dcaff"
+  integrity sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=
 
 requizzle@~0.2.1:
   version "0.2.1"
@@ -7965,13 +8002,6 @@ through@2, "through@>=2.2.7 <3", through@^2.3.4, through@^2.3.6:
   resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
   integrity sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=
 
-"tic.api.js@git+https://github.com/TangleID/tic.api.js.git#develop":
-  version "0.5.4"
-  resolved "git+https://github.com/TangleID/tic.api.js.git#f36bbc2eb6ad42682c040d44930868f50c175a38"
-  dependencies:
-    extend "^3.0.1"
-    mam.tools.js "git+https://git@github.com/TangleID/mam.tools.js.git#develop"
-
 tmp@^0.0.33:
   version "0.0.33"
   resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.0.33.tgz#6d34335889768d21b2bcda0aa277ced3b1bfadf9"
@@ -8275,6 +8305,14 @@ urix@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/urix/-/urix-0.1.0.tgz#da937f7a62e21fec1fd18d49b35c2935067a6c72"
   integrity sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=
+
+url-parse@^1.4.7:
+  version "1.4.7"
+  resolved "https://registry.yarnpkg.com/url-parse/-/url-parse-1.4.7.tgz#a8a83535e8c00a316e403a5db4ac1b9b853ae278"
+  integrity sha512-d3uaVyzDB9tQoSXFvuSUNFibTd9zxd2bkVrDRvF5TmvWWQwqE4lgYJ5m+x1DbecWkw+LK4RNl2CU1hHuOKPVlg==
+  dependencies:
+    querystringify "^2.1.1"
+    requires-port "^1.0.0"
 
 url-template@^2.0.8:
   version "2.0.8"


### PR DESCRIPTION
Using the "tic.api.js" API to register the identifier spends lots of
time, because it create multiple channels.

To simplify the registration workflow, we use the "mam.tools.js" to
replace the "tic.api.js", and create a channel to store each revision
of DID document, and use the channel root of the first message to
generated DID.

The DID schema is changed to "did:tangle:{channel-root}_".

The "tic.api.js" package is dropped.